### PR TITLE
fix: bump `phpseclib/phpseclib`

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,20 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'snyk:lic:composer:simplesamlphp:saml2:LGPL-2.1':
+    - '*':
+        reason: None Given
+        expires: 2025-12-21T13:19:41.434Z
+        created: 2023-12-21T13:19:41.438Z
+  'snyk:lic:composer:phprtflite:phprtflite:GPL-3.0':
+    - '*':
+        reason: None Given
+        expires: 2025-12-21T13:19:58.736Z
+        created: 2023-12-21T13:19:58.747Z
+  'snyk:lic:composer:behat:transliterator:Artistic-1.0':
+    - '*':
+        reason: None Given
+        expires: 2025-12-21T13:20:17.993Z
+        created: 2023-12-21T13:20:18.004Z
+patch: {}

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "olcs/olcs-xmltools": "^5.0.0",
         "oro/doctrine-extensions": "^2",
         "phprtflite/phprtflite": "~1.3.3",
-        "phpseclib/phpseclib": "^2.0.6",
+        "phpseclib/phpseclib": "^3.0",
         "qandidate/toggle": "^1.1",
         "ramsey/uuid": "^3.6",
         "ruflin/elastica": "7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d0e7eb2a9ce23340fc16f7205d82a57",
+    "content-hash": "33a17b2be4ea19d6515acbd42876b6c1",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -6560,6 +6560,73 @@
             "time": "2022-05-10T14:09:20+00:00"
         },
         {
+            "name": "paragonie/constant_time_encoding",
+            "version": "v2.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/constant_time_encoding.git",
+                "reference": "58c3f47f650c94ec05a151692652a868995d2938"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/58c3f47f650c94ec05a151692652a868995d2938",
+                "reference": "58c3f47f650c94ec05a151692652a868995d2938",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7|^8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6|^7|^8|^9",
+                "vimeo/psalm": "^1|^2|^3|^4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\ConstantTime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve 'Sc00bz' Thomas",
+                    "email": "steve@tobtu.com",
+                    "homepage": "https://www.tobtu.com",
+                    "role": "Original Developer"
+                }
+            ],
+            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
+            "keywords": [
+                "base16",
+                "base32",
+                "base32_decode",
+                "base32_encode",
+                "base64",
+                "base64_decode",
+                "base64_encode",
+                "bin2hex",
+                "encoding",
+                "hex",
+                "hex2bin",
+                "rfc4648"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
+            "time": "2022-06-14T06:56:20+00:00"
+        },
+        {
             "name": "phprtflite/phprtflite",
             "version": "v1.3.3",
             "source": {
@@ -6598,32 +6665,32 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "2.0.45",
+            "version": "3.0.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "28d8f438a0064c9de80857e3270d071495544640"
+                "reference": "56c79f16a6ae17e42089c06a2144467acc35348a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/28d8f438a0064c9de80857e3270d071495544640",
-                "reference": "28d8f438a0064c9de80857e3270d071495544640",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/56c79f16a6ae17e42089c06a2144467acc35348a",
+                "reference": "56c79f16a6ae17e42089c06a2144467acc35348a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "paragonie/constant_time_encoding": "^1|^2",
+                "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
+                "php": ">=5.6.1"
             },
             "require-dev": {
-                "phing/phing": "~2.7",
-                "phpunit/phpunit": "^4.8.35|^5.7|^6.0|^9.4",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "*"
             },
             "suggest": {
+                "ext-dom": "Install the DOM extension to load XML formatted public keys.",
                 "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
                 "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
                 "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
-                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations.",
-                "ext-xml": "Install the XML extension to load XML formatted public keys."
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
             },
             "type": "library",
             "autoload": {
@@ -6631,7 +6698,7 @@
                     "phpseclib/bootstrap.php"
                 ],
                 "psr-4": {
-                    "phpseclib\\": "phpseclib/"
+                    "phpseclib3\\": "phpseclib/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -6688,7 +6755,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/2.0.45"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.34"
             },
             "funding": [
                 {
@@ -6704,7 +6771,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-15T20:55:47+00:00"
+            "time": "2023-11-27T11:13:31+00:00"
         },
         {
             "name": "psr/cache",

--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -15,7 +15,7 @@
 return array(
     'olcs-doctrine' => [
         // Default encryption key to use if not overridden in local
-        'encryption_key' => 'ASaoW9TQogBu7TgDHoBKtsDPY5BdjF7WFZbLKHgN'
+        'encryption_key' => 'ASaoW9TQogBu7TgDHoBKtsDPY5BdjF7W'
     ],
     'doctrine' => array(
         'configuration' => array(

--- a/config/autoload/local.php.dist
+++ b/config/autoload/local.php.dist
@@ -82,14 +82,6 @@ return [
             ]
         ],
     ],
-
-    // Key used to encrypt data stored in the Doctrine EncryptedStringType
-    'olcs-doctrine' => [
-        // The encryption key used for storing encrypted data in the database
-        'encryption_key' => 'ABCDEFGHIJKLM'
-    ],
-
-
     // Companies house XML gateway credentials
     'companies_house_credentials' => [
         // Companies house XML gateway userID *Environment specific*

--- a/module/Api/src/Entity/Types/EncryptedStringType.php
+++ b/module/Api/src/Entity/Types/EncryptedStringType.php
@@ -4,8 +4,7 @@ namespace Dvsa\Olcs\Api\Entity\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\StringType;
-use phpseclib\Crypt;
-use phpseclib\Crypt\Base;
+use phpseclib3\Crypt\Common\BlockCipher;
 
 /**
  * Class EncryptedStringType
@@ -15,7 +14,7 @@ class EncryptedStringType extends StringType
     public const TYPE = 'encrypted_string';
 
     /**
-     * @var Crypt\Base
+     * @var BlockCipher
      */
     private $encrypter;
 
@@ -58,11 +57,11 @@ class EncryptedStringType extends StringType
     /**
      * Set the Encrypter to use
      *
-     * @param Base|null $ciper Cipher to use for encryption
+     * @param BlockCipher|null $ciper Cipher to use for encryption
      *
      * @return void
      */
-    public function setEncrypter(?Base $ciper)
+    public function setEncrypter(?BlockCipher $ciper)
     {
         $this->encrypter = $ciper;
     }
@@ -70,7 +69,7 @@ class EncryptedStringType extends StringType
     /**
      * Get the Encrypter
      *
-     * @return Crypt\Base
+     * @return BlockCipher
      */
     public function getEncrypter()
     {

--- a/module/Api/src/Entity/Types/EncryptedStringType.php
+++ b/module/Api/src/Entity/Types/EncryptedStringType.php
@@ -4,7 +4,7 @@ namespace Dvsa\Olcs\Api\Entity\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\StringType;
-use phpseclib3\Crypt\Common\BlockCipher;
+use phpseclib3\Crypt\Common\SymmetricKey;
 
 /**
  * Class EncryptedStringType
@@ -14,7 +14,7 @@ class EncryptedStringType extends StringType
     public const TYPE = 'encrypted_string';
 
     /**
-     * @var BlockCipher
+     * @var SymmetricKey
      */
     private $encrypter;
 
@@ -57,11 +57,11 @@ class EncryptedStringType extends StringType
     /**
      * Set the Encrypter to use
      *
-     * @param BlockCipher|null $ciper Cipher to use for encryption
+     * @param SymmetricKey|null $ciper Cipher to use for encryption
      *
      * @return void
      */
-    public function setEncrypter(?BlockCipher $ciper)
+    public function setEncrypter(?SymmetricKey $ciper)
     {
         $this->encrypter = $ciper;
     }
@@ -69,7 +69,7 @@ class EncryptedStringType extends StringType
     /**
      * Get the Encrypter
      *
-     * @return BlockCipher
+     * @return SymmetricKey
      */
     public function getEncrypter()
     {

--- a/module/Api/src/Module.php
+++ b/module/Api/src/Module.php
@@ -4,11 +4,12 @@ namespace Dvsa\Olcs\Api;
 
 use Dvsa\Olcs\Api\Domain\Util\BlockCipher\PhpSecLib;
 use Olcs\Logging\Log\Logger;
-use phpseclib\Crypt;
+use phpseclib3\Crypt\AES;
 use Laminas\EventManager\EventInterface;
 use Laminas\ModuleManager\Feature\BootstrapListenerInterface;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Mvc\ResponseSender\SendResponseEvent;
+use phpseclib3\Crypt\Common\SymmetricKey;
 
 /**
  * Module class
@@ -115,7 +116,7 @@ class Module implements BootstrapListenerInterface
             $encrypterType = \Doctrine\DBAL\Types\Type::getType('encrypted_string');
 
             // NB OLCS-17482 caused a backwards INCOMPATIBLE change to the way the encryption works
-            $cipher = new Crypt\AES();
+            $cipher = new AES('cbc');
             // Force AES 256
             $cipher->setKeyLength(256);
             $cipher->setKey($config['olcs-doctrine']['encryption_key']);

--- a/module/Api/src/Module.php
+++ b/module/Api/src/Module.php
@@ -2,14 +2,12 @@
 
 namespace Dvsa\Olcs\Api;
 
-use Dvsa\Olcs\Api\Domain\Util\BlockCipher\PhpSecLib;
 use Olcs\Logging\Log\Logger;
 use phpseclib3\Crypt\AES;
 use Laminas\EventManager\EventInterface;
 use Laminas\ModuleManager\Feature\BootstrapListenerInterface;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Mvc\ResponseSender\SendResponseEvent;
-use phpseclib3\Crypt\Common\SymmetricKey;
 
 /**
  * Module class

--- a/test/module/Api/src/Entity/Types/EncryptedStringTypeTest.php
+++ b/test/module/Api/src/Entity/Types/EncryptedStringTypeTest.php
@@ -3,7 +3,7 @@
 namespace Dvsa\OlcsTest\Api\Entity\Types;
 
 use Doctrine\DBAL\Platforms\MySQLPlatform;
-use phpseclib\Crypt\AES;
+use phpseclib3\Crypt\AES;
 use Mockery as m;
 use Dvsa\Olcs\Api\Entity\Types\EncryptedStringType;
 

--- a/test/module/Api/src/ModuleTest.php
+++ b/test/module/Api/src/ModuleTest.php
@@ -6,7 +6,7 @@ use Dvsa\Olcs\Api\Module;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Olcs\Logging\Log\Logger;
-use phpseclib\Crypt\Base;
+use phpseclib3\Crypt\AES;
 use Laminas\EventManager\Event;
 use Laminas\Mvc\Application;
 use Laminas\Mvc\ResponseSender\SendResponseEvent;
@@ -153,13 +153,12 @@ class ModuleTest extends MockeryTestCase
         if (!EncryptedStringType::hasType(EncryptedStringType::TYPE)) {
             EncryptedStringType::addType(EncryptedStringType::TYPE, EncryptedStringType::class);
         }
-        $this->sut->initDoctrineEncrypterType(['olcs-doctrine' => ['encryption_key' => 'key']]);
+        $this->sut->initDoctrineEncrypterType(['olcs-doctrine' => ['encryption_key' => 'ASaoW9TQogBu7TgDHoBKtsDPY5BdjF7W']]);
 
-        /** @var Base $ciper */
+        /** @var AES $ciper */
         $ciper = \Doctrine\DBAL\Types\Type::getType('encrypted_string')->getEncrypter();
 
-        $this->assertInstanceOf(Base::class, $ciper);
-        $this->assertSame('key', $ciper->key);
+        $this->assertInstanceOf(AES::class, $ciper);
     }
 
     /**


### PR DESCRIPTION
## Description

To fix:
- https://security.snyk.io/vuln/SNYK-PHP-PHPSECLIBPHPSECLIB-6091625

Added `.snyk` file to ignore licence warnings of dependencies to resolve:
- https://snyk.io/vuln/snyk:lic:composer:phprtflite:phprtflite:GPL-3.0
- https://snyk.io/vuln/snyk:lic:composer:simplesamlphp:saml2:LGPL-2.1
- https://snyk.io/vuln/snyk:lic:composer:behat:transliterator:Artistic-1.0