### PR TITLE
fix: assume zero-exit code for print shell commands if not set

### DIFF
--- a/module/Api/src/Domain/CommandHandler/PrintScheduler/PrintJob.php
+++ b/module/Api/src/Domain/CommandHandler/PrintScheduler/PrintJob.php
@@ -230,7 +230,7 @@ class PrintJob extends AbstractCommandHandler
         );
 
         $output = [];
-        $result = 1;
+        $result = 0;
 
         $this->executeCommand($command, $output, $result);
 
@@ -289,7 +289,7 @@ class PrintJob extends AbstractCommandHandler
         );
 
         $outputPrint = [];
-        $resultPrint = 1;
+        $resultPrint = 0;
 
         $this->executeCommand($commandPrint, $outputPrint, $resultPrint);
         if ($resultPrint !== 0) {
@@ -452,7 +452,7 @@ class PrintJob extends AbstractCommandHandler
             );
 
             $outputPdf = [];
-            $resultPdf = 1;
+            $resultPdf = 0;
 
             $this->executeCommand($commandPdf, $outputPdf, $resultPdf);
             if ($resultPdf !== 0) {

--- a/test/module/Api/src/Domain/CommandHandler/PrintScheduler/PrintJobTest.php
+++ b/test/module/Api/src/Domain/CommandHandler/PrintScheduler/PrintJobTest.php
@@ -367,7 +367,7 @@ class PrintJobTest extends CommandHandlerTestCase
             ->andReturn('TEMP_FILE.rtf');
 
         $this->sut->shouldReceive('executeCommand')
-            ->with("soffice --headless --convert-to pdf:writer_pdf_Export --outdir /tmp 'TEMP_FILE.rtf' 2>&1", [], 1)
+            ->with("soffice --headless --convert-to pdf:writer_pdf_Export --outdir /tmp 'TEMP_FILE.rtf' 2>&1", [], 0)
             ->once()
             ->andReturnUsing(
                 function ($command, &$output, &$result) {
@@ -390,7 +390,7 @@ class PrintJobTest extends CommandHandlerTestCase
             ->with(
                 "soffice --headless --convert-to pdf:writer_pdf_Export --outdir /tmp 'TEMP_FILE2.rtf' 2>&1",
                 [],
-                1
+                0
             )
             ->once()
             ->andReturnUsing(
@@ -405,7 +405,7 @@ class PrintJobTest extends CommandHandlerTestCase
             ->with(
                 "pdfunite 'TEMP_FILE.pdf' 'TEMP_FILE2.pdf' '/tmp/PrintJob-QUEUE_ID-print.pdf' 2>&1",
                 [],
-                1
+                0
             )
             ->once()
             ->andReturnUsing(
@@ -429,7 +429,7 @@ class PrintJobTest extends CommandHandlerTestCase
                 " -o collate=true" .
                 " 2>&1",
                 [],
-                1
+                0
             )->once()
             ->andReturnUsing(
                 function ($command, &$output, &$result) {
@@ -469,7 +469,7 @@ class PrintJobTest extends CommandHandlerTestCase
             ->andReturn('TEMP_FILE.rtf');
 
         $this->sut->shouldReceive('executeCommand')
-            ->with("soffice --headless --convert-to pdf:writer_pdf_Export --outdir /tmp 'TEMP_FILE.rtf' 2>&1", [], 1)
+            ->with("soffice --headless --convert-to pdf:writer_pdf_Export --outdir /tmp 'TEMP_FILE.rtf' 2>&1", [], 0)
             ->once()
             ->andReturnUsing(
                 function ($command, &$output, &$result) {
@@ -492,7 +492,7 @@ class PrintJobTest extends CommandHandlerTestCase
             ->with(
                 "soffice --headless --convert-to pdf:writer_pdf_Export --outdir /tmp 'TEMP_FILE2.rtf' 2>&1",
                 [],
-                1
+                0
             )
             ->once()
             ->andReturnUsing(
@@ -507,7 +507,7 @@ class PrintJobTest extends CommandHandlerTestCase
             ->with(
                 "pdfunite 'TEMP_FILE.pdf' 'TEMP_FILE2.pdf' '/tmp/PrintJob-QUEUE_ID-print.pdf' 2>&1",
                 [],
-                1
+                0
             )
             ->once()
             ->andReturnUsing(
@@ -531,7 +531,7 @@ class PrintJobTest extends CommandHandlerTestCase
                 " -o collate=true" .
                 " 2>&1",
                 [],
-                1
+                0
             )->never();
 
         $this->sut->shouldReceive('deleteTempFiles')->withNoArgs()->once();
@@ -629,7 +629,7 @@ class PrintJobTest extends CommandHandlerTestCase
         $copies = 1
     ) {
         $this->sut->shouldReceive('executeCommand')
-            ->with("soffice --headless --convert-to pdf:writer_pdf_Export --outdir /tmp 'TEMP_FILE.rtf' 2>&1", [], 1)
+            ->with("soffice --headless --convert-to pdf:writer_pdf_Export --outdir /tmp 'TEMP_FILE.rtf' 2>&1", [], 0)
             ->once()
             ->andReturnUsing(
                 function ($command, &$output, &$result) use ($commandPdfResult) {
@@ -662,7 +662,7 @@ class PrintJobTest extends CommandHandlerTestCase
                 " -o collate=true" .
                 " 2>&1",
                 [],
-                1
+                0
             )->once()
             ->andReturnUsing(
                 function ($command, &$output, &$result) use ($commandLprResult) {


### PR DESCRIPTION
## Description

The printing shell commands aren't seemingly returning 0 exit codes. This changes the code to assume that if no output then the command ran successfully. 