### PR TITLE
fix: correct test data provider method names

### DIFF
--- a/module/AcquiredRights/test/Client/Mapper/ApplicationReferenceMapperTest.php
+++ b/module/AcquiredRights/test/Client/Mapper/ApplicationReferenceMapperTest.php
@@ -18,7 +18,7 @@ class ApplicationReferenceMapperTest extends MockeryTestCase
 
     /**
      * @test
-     * @dataProvider dataProvider_responseDataAndExceptionMap
+     * @dataProvider dataProviderresponseDataAndExceptionMap
      */
     public function createFromResponseArrayValidOrThrowsAppropriateExceptions(array $data, string $exceptionMessage = null)
     {

--- a/module/AcquiredRights/test/Client/Mapper/ApplicationReferenceMapperTest.php
+++ b/module/AcquiredRights/test/Client/Mapper/ApplicationReferenceMapperTest.php
@@ -18,7 +18,7 @@ class ApplicationReferenceMapperTest extends MockeryTestCase
 
     /**
      * @test
-     * @dataProvider dataProviderresponseDataAndExceptionMap
+     * @dataProvider dataProviderResponseDataAndExceptionMap
      */
     public function createFromResponseArrayValidOrThrowsAppropriateExceptions(array $data, string $exceptionMessage = null)
     {
@@ -32,7 +32,7 @@ class ApplicationReferenceMapperTest extends MockeryTestCase
         $this->sut::createFromResponseArray($data);
     }
 
-    public function dataProviderresponseDataAndExceptionMap(): array
+    public function dataProviderResponseDataAndExceptionMap(): array
     {
         return [
             'Valid' => [

--- a/module/AcquiredRights/test/Exception/Mapper/AcquiredRightsExceptionToValidationExceptionMapperTest.php
+++ b/module/AcquiredRights/test/Exception/Mapper/AcquiredRightsExceptionToValidationExceptionMapperTest.php
@@ -15,7 +15,7 @@ class AcquiredRightsExceptionToValidationExceptionMapperTest extends MockeryTest
 
     /**
      * @test
-     * @dataProvider dataProviderexceptionMap
+     * @dataProvider dataProviderExceptionMap
      */
     public function mapExceptionThrowsValidationExceptionOnMappedExceptions(string $exception, string $key, string $message)
     {
@@ -57,7 +57,7 @@ class AcquiredRightsExceptionToValidationExceptionMapperTest extends MockeryTest
         $this->assertFalse($result);
     }
 
-    public function dataProviderexceptionMap(): array
+    public function dataProviderExceptionMap(): array
     {
         $result = [];
 

--- a/module/AcquiredRights/test/Exception/Mapper/AcquiredRightsExceptionToValidationExceptionMapperTest.php
+++ b/module/AcquiredRights/test/Exception/Mapper/AcquiredRightsExceptionToValidationExceptionMapperTest.php
@@ -15,7 +15,7 @@ class AcquiredRightsExceptionToValidationExceptionMapperTest extends MockeryTest
 
     /**
      * @test
-     * @dataProvider dataProvider_exceptionMap
+     * @dataProvider dataProviderexceptionMap
      */
     public function mapExceptionThrowsValidationExceptionOnMappedExceptions(string $exception, string $key, string $message)
     {

--- a/module/AcquiredRights/test/Service/AcquiredRightsServiceTest.php
+++ b/module/AcquiredRights/test/Service/AcquiredRightsServiceTest.php
@@ -96,7 +96,7 @@ class AcquiredRightsServiceTest extends MockeryTestCase
 
     /**
      * @test
-     * @dataProvider dataProviderverifyAcquiredRightsByReferenceApplicationNotApproved
+     * @dataProvider dataProviderVerifyAcquiredRightsByReferenceApplicationNotApproved
      */
     public function verifyAcquiredRightsByReferenceApplicationNotApprovedThrowsAcquiredRightsNotApprovedException(string $status, bool $shouldThrow)
     {
@@ -123,7 +123,7 @@ class AcquiredRightsServiceTest extends MockeryTestCase
         $this->sut->verifyAcquiredRightsByReference('ABC1234', $dateOfBirth);
     }
 
-    public function dataProviderverifyAcquiredRightsByReferenceApplicationNotApproved(): array
+    public function dataProviderVerifyAcquiredRightsByReferenceApplicationNotApproved(): array
     {
         return [
             ApplicationReference::APPLICATION_STATUS_SUBMITTED => [

--- a/module/AcquiredRights/test/Service/AcquiredRightsServiceTest.php
+++ b/module/AcquiredRights/test/Service/AcquiredRightsServiceTest.php
@@ -96,7 +96,7 @@ class AcquiredRightsServiceTest extends MockeryTestCase
 
     /**
      * @test
-     * @dataProvider dataProvider_verifyAcquiredRightsByReference_ApplicationNotApproved
+     * @dataProvider dataProviderverifyAcquiredRightsByReferenceApplicationNotApproved
      */
     public function verifyAcquiredRightsByReferenceApplicationNotApprovedThrowsAcquiredRightsNotApprovedException(string $status, bool $shouldThrow)
     {

--- a/module/Auth/test/Adapter/CognitoAdapterTest.php
+++ b/module/Auth/test/Adapter/CognitoAdapterTest.php
@@ -828,7 +828,7 @@ class CognitoAdapterTest extends MockeryTestCase
 
     /**
      * @test
-     * @dataProvider dataProvidergetIdentityStrings
+     * @dataProvider dataProviderGetIdentityStrings
      * @param string $identity
      */
     public function getIdentityresultDoesNotContainUppercaseAndCaseConvertsToLowercase(string $identity): void
@@ -840,7 +840,7 @@ class CognitoAdapterTest extends MockeryTestCase
         $this->assertDoesNotMatchRegularExpression('/[A-Z]+/', $sut->getIdentity());
     }
 
-    public function dataProvidergetIdentityStrings(): array
+    public function dataProviderGetIdentityStrings(): array
     {
         return [
             'Lowercase' => ['testing'],

--- a/module/Auth/test/Adapter/CognitoAdapterTest.php
+++ b/module/Auth/test/Adapter/CognitoAdapterTest.php
@@ -828,7 +828,7 @@ class CognitoAdapterTest extends MockeryTestCase
 
     /**
      * @test
-     * @dataProvider dataProvider_getIdentityStrings
+     * @dataProvider dataProvidergetIdentityStrings
      * @param string $identity
      */
     public function getIdentityresultDoesNotContainUppercaseAndCaseConvertsToLowercase(string $identity): void

--- a/test/module/Api/src/Domain/CommandHandler/Application/UpdateVariationCompletionTest.php
+++ b/test/module/Api/src/Domain/CommandHandler/Application/UpdateVariationCompletionTest.php
@@ -1187,7 +1187,7 @@ class UpdateVariationCompletionTest extends CommandHandlerTestCase
 
     /**
      * @depends handleCommandIsCallable
-     * @dataProvidert dpMarksFinancialEvidenceSectionAsRequiringAttentionIfApplicationAmountDoesntExceedLicenceAmount
+     * @dataProvider dpMarksFinancialEvidenceSectionAsRequiringAttentionIfApplicationAmountDoesntExceedLicenceAmount
      */
     public function testMarksFinancialEvidenceSectionAsRequiringAttentionIfApplicationAmountDoesntExceedLicenceAmount(
         $applicationRequiredFinance


### PR DESCRIPTION
## Description

Some test data provider names were not updated with the migration PR. This links them back to their respective provider.