### PR TITLE
fix: improve stability of unit tests

### DIFF
--- a/module/Cpms/test/Client/HttpClientTest.php
+++ b/module/Cpms/test/Client/HttpClientTest.php
@@ -7,7 +7,7 @@ use Dvsa\Olcs\Cpms\Client\HttpClient;
 use GuzzleHttp\Client;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
 use GuzzleHttp\Psr7\Response;
 use Mockery as m;
 

--- a/module/Cpms/test/Service/ApiServiceTest.php
+++ b/module/Cpms/test/Service/ApiServiceTest.php
@@ -12,7 +12,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
 use Mockery as m;
 
 class ApiServiceTest extends TestCase

--- a/test/module/Api/src/Service/Cpms/ApiServiceFactoryTest.php
+++ b/test/module/Api/src/Service/Cpms/ApiServiceFactoryTest.php
@@ -5,7 +5,7 @@ namespace Dvsa\OlcsTest\Api\Service\Cpms;
 use Dvsa\Olcs\Api\Service\Cpms\ApiServiceFactory;
 use Dvsa\Olcs\Cpms\Service\ApiService;
 use Interop\Container\ContainerInterface;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
 use Mockery as m;
 use LmcRbacMvc\Service\AuthorizationService;
 

--- a/test/module/Api/src/Service/Document/DocumentTest.php
+++ b/test/module/Api/src/Service/Document/DocumentTest.php
@@ -7,8 +7,7 @@ use Dvsa\Olcs\Api\Service\Document\Document;
 use Dvsa\Olcs\DocumentShare\Data\Object\File;
 use Dvsa\Olcs\DocumentShare\Service\DocumentStoreInterface;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObj;
+use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
 use Laminas\I18n\Translator\TranslatorInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 

--- a/test/module/Api/src/Service/DvlaSearch/DvlaSearchServiceFactoryTest.php
+++ b/test/module/Api/src/Service/DvlaSearch/DvlaSearchServiceFactoryTest.php
@@ -5,7 +5,7 @@ namespace Dvsa\OlcsTest\Api\Service\DvlaSearch;
 use Dvsa\Olcs\Api\Service\DvlaSearch\DvlaSearchServiceFactory;
 use Dvsa\Olcs\Api\Service\DvlaSearch\DvlaSearchService as DvlaSearchServiceClient;
 use Interop\Container\ContainerInterface;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
 use Mockery as m;
 
 class DvlaSearchServiceFactoryTest extends TestCase

--- a/test/module/Api/src/Service/Ebsr/Filter/InjectIsTxcAppTest.php
+++ b/test/module/Api/src/Service/Ebsr/Filter/InjectIsTxcAppTest.php
@@ -3,7 +3,7 @@
 namespace Dvsa\OlcsTest\Api\Service\Ebsr\Filter;
 
 use Dvsa\Olcs\Api\Service\Ebsr\Filter\InjectIsTxcApp;
-use PHPUnit\Framework\TestCase as TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
 use Dvsa\Olcs\Api\Entity\Bus\BusReg as BusRegEntity;
 
 /**

--- a/test/module/Api/src/Service/Ebsr/RulesValidator/EffectiveDateTest.php
+++ b/test/module/Api/src/Service/Ebsr/RulesValidator/EffectiveDateTest.php
@@ -3,7 +3,7 @@
 namespace Dvsa\OlcsTest\Api\Service\Ebsr\RulesValidator;
 
 use Dvsa\Olcs\Api\Service\Ebsr\RulesValidator\EffectiveDate;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Dvsa\Olcs\Api\Entity\Bus\BusReg as BusRegEntity;
 
 /**

--- a/test/module/AwsSdk/src/Factories/S3ClientFactoryTest.php
+++ b/test/module/AwsSdk/src/Factories/S3ClientFactoryTest.php
@@ -7,7 +7,7 @@ use Aws\S3\S3Client;
 use Dvsa\Olcs\AwsSdk\Factories\S3ClientFactory;
 use Laminas\ServiceManager\ServiceManager;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
 
 /**
  * Class S3ClientTest

--- a/test/module/AwsSdk/src/Factories/SqsClientFactoryTest.php
+++ b/test/module/AwsSdk/src/Factories/SqsClientFactoryTest.php
@@ -5,7 +5,7 @@ namespace Dvsa\OlcsTest\AwsSdk\Factories;
 use Aws\Sqs\SqsClient;
 use Dvsa\Olcs\AwsSdk\Factories\SqsClientFactory;
 use Laminas\ServiceManager\ServiceManager;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
 use Mockery as m;
 use Aws\Credentials\CredentialsInterface;
 

--- a/test/module/Queue/src/Factories/MessageBuilderFactoryTest.php
+++ b/test/module/Queue/src/Factories/MessageBuilderFactoryTest.php
@@ -5,7 +5,7 @@ namespace OlcsTest\Queue\Factories;
 use Dvsa\Olcs\Queue\Factories\MessageBuilderFactory;
 use Dvsa\Olcs\Queue\Service\Message\MessageBuilder;
 use Interop\Container\ContainerInterface;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
 use Mockery as m;
 
 class MessageBuilderFactoryTest extends TestCase

--- a/test/module/Queue/src/Factories/QueueFactoryTest.php
+++ b/test/module/Queue/src/Factories/QueueFactoryTest.php
@@ -6,7 +6,7 @@ use Aws\Sqs\SqsClient;
 use Dvsa\Olcs\Queue\Factories\QueueFactory;
 use Dvsa\Olcs\Queue\Service\Queue;
 use Laminas\ServiceManager\ServiceManager;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
 use Mockery as m;
 
 class QueueFactoryTest extends TestCase


### PR DESCRIPTION
## Description

The unit tests part of this PR used Mockery to mock objects, however didn't include a tear down (provided by the `MockeryTestCase`). This caused flakiness in other tests.

This PR updates the parent of tests that require a Mockery tear down.