### PR TITLE
fix: further unit test stability improvements

### DIFF
--- a/test/module/Api/src/Domain/CommandHandler/CommandHandlerTestCase.php
+++ b/test/module/Api/src/Domain/CommandHandler/CommandHandlerTestCase.php
@@ -206,29 +206,10 @@ abstract class CommandHandlerTestCase extends MockeryTestCase
         }
     }
 
-    public function tearDown(): void
+    protected function assertPostConditions(): void
     {
         $this->initRefdata = false;
         $this->assertCommandData();
-
-        m::close();
-        parent::tearDown();
-
-        unset(
-            $this->sut,
-            $this->commandHandler,
-            $this->repoManager,
-            $this->repoMap,
-            $this->sideEffects,
-            $this->commands,
-            $this->refData,
-            $this->references,
-            $this->categoryReferences,
-            $this->subCategoryReferences,
-            $this->initRefdata,
-            $this->mockedSmServices,
-            $this->pidIdentityProvider
-        );
     }
 
     public function expectedCacheSideEffect($cacheId, $uniqueId = null, $result = null, $times = 1)

--- a/test/module/Api/src/Domain/CommandHandler/Fee/RefundFeeTest.php
+++ b/test/module/Api/src/Domain/CommandHandler/Fee/RefundFeeTest.php
@@ -123,7 +123,7 @@ class RefundFeeTest extends CommandHandlerTestCase
         $fee->setFeeTransactions(new ArrayCollection([$ft1, $ft2, $ft3]));
         $fee->shouldReceive('getFeeTransactionsForRefund')
             ->andReturn(new ArrayCollection([$ft1, $ft2, $ft3]));
-        $fee->shouldReceive('getFeetype->getFeeType')->andReturn(new RefData(FeeType::FEE_TYPE_GRANT));
+        $fee->shouldReceive('getFeeType->getFeeType')->andReturn(new RefData(FeeType::FEE_TYPE_GRANT));
 
         $command = Cmd::create($data);
 

--- a/test/module/Api/src/Domain/QueryHandler/QueryHandlerTestCase.php
+++ b/test/module/Api/src/Domain/QueryHandler/QueryHandlerTestCase.php
@@ -190,27 +190,10 @@ class QueryHandlerTestCase extends MockeryTestCase
         return isset($this->references[$class][$id]) ? $this->references[$class][$id] : null;
     }
 
-    public function tearDown(): void
+    protected function assertPostConditions(): void
     {
         $this->assertCommandData();
         $this->assertQueryData();
-
-        parent::tearDown();
-
-        unset(
-            $this->sut,
-            $this->queryHandler,
-            $this->repoManager,
-            $this->repoMap,
-            $this->commands,
-            $this->sideEffectQueries,
-            $this->refData,
-            $this->references,
-            $this->categoryReferences,
-            $this->subCategoryReferences,
-            $this->initRefdata,
-            $this->mockedSmServices
-        );
     }
 
     protected function mockRepo($name, $class)

--- a/test/module/Api/src/Domain/Repository/RepositoryTestCase.php
+++ b/test/module/Api/src/Domain/Repository/RepositoryTestCase.php
@@ -64,11 +64,6 @@ class RepositoryTestCase extends MockeryTestCase
         $this->qb = null;
     }
 
-    public function tearDown(): void
-    {
-        m::close();
-    }
-
     protected function mockCreateQueryBuilder($mock)
     {
         $this->em->shouldReceive('getRepository->createQueryBuilder')

--- a/test/module/Api/src/Entity/Abstracts/EntityTester.php
+++ b/test/module/Api/src/Entity/Abstracts/EntityTester.php
@@ -39,12 +39,6 @@ abstract class EntityTester extends MockeryTestCase
         return $this->entityClass;
     }
 
-    public function tearDown(): void
-    {
-        unset($this->entity);
-        \Mockery::close();
-    }
-
     protected function instantiate($entityName)
     {
         if (!method_exists($entityName, '__construct')) {


### PR DESCRIPTION
## Description

Removes custom `tearDown` in unit tests.
Moves assertions that happened in `tearDown` to `assertPostConditions` method (runs between the test and `tearDown`) and is the correct method for these assertions that were in the `tearDown`.