### PR TITLE
fix: refactor Laminas deprecations out of unit tests

### DIFF
--- a/test/module/Api/src/Domain/Validation/ImplementationTest.php
+++ b/test/module/Api/src/Domain/Validation/ImplementationTest.php
@@ -10,7 +10,7 @@ namespace Dvsa\OlcsTest\Api\Domain\Validation;
 
 use Dvsa\Olcs\Api\Domain\ValidationHandlerManager;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
-use Laminas\ServiceManager\Config;
+use Psr\Container\ContainerInterface;
 
 /**
  * Implementation Test
@@ -58,27 +58,13 @@ class ImplementationTest extends MockeryTestCase
             }
         }
 
-        $validationHandlerConfig = new Config($validationHandlers);
-
-        $this->validationManager = new ValidationHandlerManager($validationHandlerConfig);
+        $this->validationManager = new ValidationHandlerManager($this->createMock(ContainerInterface::class), $validationHandlers);
     }
 
     public function testAllImplemented()
     {
-        $errors = [];
-
         foreach ($this->handlers as $handler) {
-            if ($this->validationManager->has($handler) === false) {
-                $errors[] = $handler;
-            }
-        }
-
-        if (!empty($errors)) {
-            $this->fail(
-                'Validation for the following handlers has not been implemented:' . "\n" . implode("\n", $errors)
-            );
-        } else {
-            $this->assertTrue(true);
+            $this->assertTrue($this->validationManager->has($handler));
         }
     }
 }

--- a/test/module/Api/src/Service/Publication/Context/PluginManagerTest.php
+++ b/test/module/Api/src/Service/Publication/Context/PluginManagerTest.php
@@ -4,6 +4,7 @@ namespace Dvsa\OlcsTest\Api\Service\Publication\Context;
 
 use Dvsa\Olcs\Api\Service\Publication\Context\ContextInterface;
 use Dvsa\Olcs\Api\Service\Publication\Context\PluginManager;
+use Interop\Container\Containerinterface;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
@@ -17,7 +18,7 @@ class PluginManagerTest extends MockeryTestCase
 
     public function setUp(): void
     {
-        $this->sut = new PluginManager();
+        $this->sut = new PluginManager($this->createMock(ContainerInterface::class));
     }
 
     public function testValidate()

--- a/test/module/Api/src/Service/Publication/Process/PluginManagerTest.php
+++ b/test/module/Api/src/Service/Publication/Process/PluginManagerTest.php
@@ -7,6 +7,7 @@ use Dvsa\Olcs\Api\Service\Publication\Process\ProcessInterface;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
+use Psr\Container\ContainerInterface;
 
 /**
  * @covers ProcessPluginManager
@@ -17,7 +18,7 @@ class PluginManagerTest extends MockeryTestCase
 
     public function setUp(): void
     {
-        $this->sut = new ProcessPluginManager();
+        $this->sut = new ProcessPluginManager($this->createMock(ContainerInterface::class));
     }
 
     public function testValidate()

--- a/test/module/Api/src/Service/Submission/Sections/SectionGeneratorPluginManagerTest.php
+++ b/test/module/Api/src/Service/Submission/Sections/SectionGeneratorPluginManagerTest.php
@@ -7,6 +7,7 @@ use Dvsa\Olcs\Api\Service\Submission\Sections\SectionGeneratorPluginManager;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
+use Psr\Container\ContainerInterface;
 
 /**
  * @covers Dvsa\Olcs\Api\Service\Submission\Sections\SectionGeneratorPluginManager
@@ -18,7 +19,7 @@ class SectionGeneratorPluginManagerTest extends MockeryTestCase
 
     public function setUp(): void
     {
-        $this->sut = new SectionGeneratorPluginManager();
+        $this->sut = new SectionGeneratorPluginManager($this->createMock(ContainerInterface::class));
     }
 
     public function testValidate()

--- a/test/module/Cli/src/Service/Queue/MessageConsumerManagerTest.php
+++ b/test/module/Cli/src/Service/Queue/MessageConsumerManagerTest.php
@@ -36,7 +36,7 @@ class MessageConsumerManagerTest extends MockeryTestCase
 
         $this->sm = $sm;
 
-        $this->sut = new MessageConsumerManager();
+        $this->sut = new MessageConsumerManager($sm);
     }
 
     public function testValidate()

--- a/test/src/MocksRepositoriesTrait.php
+++ b/test/src/MocksRepositoriesTrait.php
@@ -25,7 +25,7 @@ trait MocksRepositoriesTrait
     {
         assert(is_callable([$this, 'serviceManager']), 'Expected service manager accessor to be defined');
         if (! $this->serviceManager()->has('RepositoryServiceManager')) {
-            $instance = new RepositoryServiceManager();
+            $instance = new RepositoryServiceManager($this->serviceManager());
             $this->serviceManager()->setService('RepositoryServiceManager', $instance);
         }
         return $this->serviceManager()->get('RepositoryServiceManager');


### PR DESCRIPTION
## Description

Fixes the following deprecation reported during unit tests:

```
PHP Deprecated:  Laminas\ServiceManager\AbstractPluginManager::__construct now expects a Psr\Container\ContainerInterface instance representing the parent container; please update your code in /home/runner/work/olcs-backend/olcs-backend/vendor/laminas/laminas-servicemanager/src/AbstractPluginManager.php on line 99
```
