### PR TITLE
feat: Close Conversation FE - add conversation in to result page

### DIFF
--- a/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversation.php
+++ b/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversation.php
@@ -17,9 +17,9 @@ class ByConversation extends AbstractQueryHandler implements ToggleRequiredInter
 {
     use ToggleAwareTrait;
 
-    protected $toggleConfig = [FeatureToggle::MESSAGING];
+    protected array $toggleConfig = [FeatureToggle::MESSAGING];
 
-    protected $extraRepos = ['Conversation','Message','MessageContent'];
+    protected $extraRepos = ['Conversation', 'Message', 'MessageContent'];
 
     public function handleQuery(QueryInterface $query)
     {
@@ -36,6 +36,7 @@ class ByConversation extends AbstractQueryHandler implements ToggleRequiredInter
         return [
             'result' => $messages,
             'count' => $messageRepository->fetchPaginatedCount($messagesQuery),
+            'conversation' => $this->getRepo('Conversation')->fetchById($query->getConversation()),
         ];
     }
 }


### PR DESCRIPTION
## Description

Add the conversation data to the conversation message page to support checking isClosed.

Related issue: [VOL-4689](https://dvsa.atlassian.net/browse/VOL-4689)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
