### PR TITLE
fix: Conversation added to message list page broke test. Refactor of Close missed in map.

### DIFF
--- a/module/Api/config/command-map.config.php
+++ b/module/Api/config/command-map.config.php
@@ -1050,7 +1050,7 @@ return [
         CommandHandler\FeatureToggle\Delete::class,
 
     // Transfer - Messaging
-    TransferCommand\Messaging\Close::class =>
+    TransferCommand\Messaging\Conversation\Close::class =>
         CommandHandler\Messaging\Conversation\Close::class,
 
     // Transfer - IRHP Permit

--- a/test/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversationTest.php
+++ b/test/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversationTest.php
@@ -45,11 +45,16 @@ class ByConversationTest extends QueryHandlerTestCase
                 ['id' => 8,'messaging_conversation_id' => '1','messaging_content_id' => '8'],
             ]
         );
+        $conversation = [
+            'id' => 1,
+            'isDisabled' => false,
+        ];
         $mockQb = m::mock(QueryBuilder::class);
         $this->repoMap['Message']->shouldReceive('getBaseMessageListWithContentQuery')->andReturn($mockQb);
         $this->repoMap['Message']->shouldReceive('filterByConversationId')->andReturn($mockQb);
         $this->repoMap['Message']->shouldReceive('fetchPaginatedList')->with($mockQb)->once()->andReturn($messages);
         $this->repoMap['Message']->shouldReceive('fetchPaginatedCount')->with($mockQb)->once()->andReturn(10);
+        $this->repoMap['Conversation']->shouldReceive('fetchById')->with(1)->once()->andReturn($conversation);
 
         $result = $this->sut->handleQuery($query);
 


### PR DESCRIPTION
## Description

Adding the conversation object to the message list page broke the list page query handler test.
Refactor of Close class did not pick up the command map php change.

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
