### PR TITLE
fix: Block Conversation Close with feature flag

### DIFF
--- a/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Close.php
+++ b/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Close.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Dvsa\Olcs\Api\Domain\CommandHandler\Messaging\Conversation;
 
+use Dvsa\Olcs\Api\Domain\ToggleAwareTrait;
+use Dvsa\Olcs\Api\Domain\ToggleRequiredInterface;
+use Dvsa\Olcs\Api\Entity\System\FeatureToggle;
 use Dvsa\Olcs\Api\Domain\Command\Result;
 use Dvsa\Olcs\Api\Domain\CommandHandler\AbstractUserCommandHandler;
 use Dvsa\Olcs\Api\Entity\Messaging\MessagingConversation;
@@ -14,9 +17,12 @@ use Dvsa\Olcs\Transfer\Command\CommandInterface;
  *
  * @author Wade Womersley <wade.womersley@dvsa.org.uk>
  */
-final class Close extends AbstractUserCommandHandler
+final class Close extends AbstractUserCommandHandler implements ToggleRequiredInterface
 {
+    use ToggleAwareTrait;
+
     protected $repoServiceName = 'Conversation';
+    protected $toggleConfig = [FeatureToggle::MESSAGING];
 
     /**
      * Close Command Handler Abstract


### PR DESCRIPTION
## Description

The command is able to be executed and handled despite the feature toggle messaging being inactive.

Related issue: [4842](https://dvsa.atlassian.net/browse/VOL-4842)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
