### PR TITLE
feat: Messaging user level disable/enable

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PHPSTORM_META {
+    override(
+        \Dvsa\Olcs\Api\Domain\CommandHandler\AbstractCommandHandler::getRepo(0),
+        type(0)
+    );
+}

--- a/composer.lock
+++ b/composer.lock
@@ -6350,12 +6350,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dvsa/olcs-transfer.git",
-                "reference": "dd10bf1ccf3e48b4aee1dc5504a912c5d9112066"
+                "reference": "6402a058b92762e2c4463527133ea824550d1e94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dvsa/olcs-transfer/zipball/dd10bf1ccf3e48b4aee1dc5504a912c5d9112066",
-                "reference": "dd10bf1ccf3e48b4aee1dc5504a912c5d9112066",
+                "url": "https://api.github.com/repos/dvsa/olcs-transfer/zipball/6402a058b92762e2c4463527133ea824550d1e94",
+                "reference": "6402a058b92762e2c4463527133ea824550d1e94",
                 "shasum": ""
             },
             "require": {
@@ -6397,7 +6397,7 @@
             "support": {
                 "source": "https://github.com/dvsa/olcs-transfer/tree/project/messaging"
             },
-            "time": "2024-01-24T14:01:14+00:00"
+            "time": "2024-01-29T10:56:13+00:00"
         },
         {
             "name": "olcs/olcs-utils",

--- a/module/Api/config/command-map.config.php
+++ b/module/Api/config/command-map.config.php
@@ -1052,6 +1052,10 @@ return [
     // Transfer - Messaging
     TransferCommand\Messaging\Conversation\Close::class =>
         CommandHandler\Messaging\Conversation\Close::class,
+    TransferCommand\Messaging\Conversation\Disable::class =>
+        CommandHandler\Messaging\Conversation\Disable::class,
+    TransferCommand\Messaging\Conversation\Enable::class =>
+        CommandHandler\Messaging\Conversation\Enable::class,
 
     // Transfer - IRHP Permit
     TransferCommand\IrhpPermit\Replace::class =>

--- a/module/Api/config/module.config.php
+++ b/module/Api/config/module.config.php
@@ -606,7 +606,7 @@ return [
             'CompanySubsidiary' => RepositoryFactory::class,
             'Conviction' => RepositoryFactory::class,
             'Decision' => RepositoryFactory::class,
-            'Organisation' => RepositoryFactory::class,
+            'Licence' => RepositoryFactory::class,
             'Bus' => RepositoryFactory::class,
             'BusRegHistory' => RepositoryFactory::class,
             'BusRegOtherService' => RepositoryFactory::class,
@@ -792,6 +792,7 @@ return [
             Repository\Licence::class => RepositoryFactory::class,
             Repository\Application::class => RepositoryFactory::class,
             Repository\MessagingSubject::class => RepositoryFactory::class,
+            Repository\Organisation::class => RepositoryFactory::class,
         ],
         'aliases' => [
             'Conversation' => Repository\Conversation::class,
@@ -799,6 +800,7 @@ return [
             'MessageContent' => Repository\MessageContent::class,
             'Licence' => Repository\Licence::class,
             'Application' => Repository\Application::class,
+            'Organisation' => Repository\Organisation::class,
         ],
     ],
     \Dvsa\Olcs\Api\Domain\FormControlServiceManagerFactory::CONFIG_KEY => [

--- a/module/Api/config/module.config.php
+++ b/module/Api/config/module.config.php
@@ -606,7 +606,6 @@ return [
             'CompanySubsidiary' => RepositoryFactory::class,
             'Conviction' => RepositoryFactory::class,
             'Decision' => RepositoryFactory::class,
-            'Licence' => RepositoryFactory::class,
             'Bus' => RepositoryFactory::class,
             'BusRegHistory' => RepositoryFactory::class,
             'BusRegOtherService' => RepositoryFactory::class,

--- a/module/Api/config/validation-map/messaging.config.php
+++ b/module/Api/config/validation-map/messaging.config.php
@@ -12,6 +12,8 @@ return [
     QueryHandler\Messaging\ApplicationLicenceList\ByLicenceToOrganisation::class => NoValidationRequired::class,
     QueryHandler\Messaging\Message\ByConversation::class               => NoValidationRequired::class,
     CommandHandler\Messaging\Conversation\Close::class                 => NoValidationRequired::class,
+    CommandHandler\Messaging\Conversation\Disable::class               => NoValidationRequired::class,
+    CommandHandler\Messaging\Conversation\Enable::class                => NoValidationRequired::class,
     CommandHandler\Messaging\Message\Create::class                     => NoValidationRequired::class,
     QueryHandler\Messaging\Conversations\ByOrganisation::class         => NoValidationRequired::class,
     QueryHandler\Messaging\Subjects\All::class                         => NoValidationRequired::class

--- a/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Disable.php
+++ b/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Disable.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Dvsa\Olcs\Api\Domain\CommandHandler\Messaging\Conversation;
 
+use Dvsa\Olcs\Api\Domain\CommandHandler\AbstractCommandHandler;
 use Dvsa\Olcs\Api\Domain\Repository\Organisation as OrganisationRepo;
 use Dvsa\Olcs\Api\Domain\ToggleAwareTrait;
 use Dvsa\Olcs\Api\Domain\ToggleRequiredInterface;
-use Dvsa\Olcs\Api\Entity\Organisation\Organisation;
 use Dvsa\Olcs\Api\Entity\System\FeatureToggle;
 use Dvsa\Olcs\Api\Domain\Command\Result;
-use Dvsa\Olcs\Api\Domain\CommandHandler\AbstractUserCommandHandler;
 use Dvsa\Olcs\Transfer\Command\CommandInterface;
 use Dvsa\Olcs\Transfer\Command\Messaging\Conversation\Disable as DisableCommand;
 
@@ -19,7 +18,7 @@ use Dvsa\Olcs\Transfer\Command\Messaging\Conversation\Disable as DisableCommand;
  *
  * @author Wade Womersley <wade.womersley@dvsa.org.uk>
  */
-final class Disable extends AbstractUserCommandHandler implements ToggleRequiredInterface
+final class Disable extends AbstractCommandHandler implements ToggleRequiredInterface
 {
     use ToggleAwareTrait;
 

--- a/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Disable.php
+++ b/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Disable.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\Olcs\Api\Domain\CommandHandler\Messaging\Conversation;
+
+use Dvsa\Olcs\Api\Domain\Repository\Organisation as OrganisationRepo;
+use Dvsa\Olcs\Api\Domain\ToggleAwareTrait;
+use Dvsa\Olcs\Api\Domain\ToggleRequiredInterface;
+use Dvsa\Olcs\Api\Entity\Organisation\Organisation;
+use Dvsa\Olcs\Api\Entity\System\FeatureToggle;
+use Dvsa\Olcs\Api\Domain\Command\Result;
+use Dvsa\Olcs\Api\Domain\CommandHandler\AbstractUserCommandHandler;
+use Dvsa\Olcs\Transfer\Command\CommandInterface;
+use Dvsa\Olcs\Transfer\Command\Messaging\Conversation\Disable as DisableCommand;
+
+/**
+ * Disable conversations
+ *
+ * @author Wade Womersley <wade.womersley@dvsa.org.uk>
+ */
+final class Disable extends AbstractUserCommandHandler implements ToggleRequiredInterface
+{
+    use ToggleAwareTrait;
+
+    protected $extraRepos = [OrganisationRepo::class];
+    protected $toggleConfig = [FeatureToggle::MESSAGING];
+
+    /** @var CommandInterface|DisableCommand $command */
+    public function handleCommand(CommandInterface $command): Result
+    {
+        $repo = $this->getRepo(OrganisationRepo::class);
+
+        $organisation = $repo->fetchById($command->getOrganisation());
+        $organisation->setIsMessagingDisabled(true);
+
+        $repo->save($organisation);
+
+        $result = new Result();
+        $result->addId('organisation', $organisation->getId());
+        $result->addMessage('Messaging disabled');
+
+        return $result;
+    }
+}

--- a/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Enable.php
+++ b/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Enable.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\Olcs\Api\Domain\CommandHandler\Messaging\Conversation;
+
+use Dvsa\Olcs\Api\Domain\Repository\Organisation as OrganisationRepo;
+use Dvsa\Olcs\Api\Domain\ToggleAwareTrait;
+use Dvsa\Olcs\Api\Domain\ToggleRequiredInterface;
+use Dvsa\Olcs\Api\Entity\Organisation\Organisation;
+use Dvsa\Olcs\Api\Entity\System\FeatureToggle;
+use Dvsa\Olcs\Api\Domain\Command\Result;
+use Dvsa\Olcs\Api\Domain\CommandHandler\AbstractUserCommandHandler;
+use Dvsa\Olcs\Transfer\Command\CommandInterface;
+use Dvsa\Olcs\Transfer\Command\Messaging\Conversation\Enable as EnableCommand;
+
+/**
+ * Enable conversations
+ *
+ * @author Wade Womersley <wade.womersley@dvsa.org.uk>
+ */
+final class Enable extends AbstractUserCommandHandler implements ToggleRequiredInterface
+{
+    use ToggleAwareTrait;
+
+    protected $extraRepos = [OrganisationRepo::class];
+    protected $toggleConfig = [FeatureToggle::MESSAGING];
+
+    /** @var CommandInterface|EnableCommand $command */
+    public function handleCommand(CommandInterface $command): Result
+    {
+        $repo = $this->getRepo(OrganisationRepo::class);
+
+        $organisation = $repo->fetchById($command->getOrganisation());
+        $organisation->setIsMessagingDisabled(false);
+
+        $repo->save($organisation);
+
+        $result = new Result();
+        $result->addId('organisation', $organisation->getId());
+        $result->addMessage('Messaging enabled');
+
+        return $result;
+    }
+}

--- a/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Enable.php
+++ b/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Enable.php
@@ -7,10 +7,9 @@ namespace Dvsa\Olcs\Api\Domain\CommandHandler\Messaging\Conversation;
 use Dvsa\Olcs\Api\Domain\Repository\Organisation as OrganisationRepo;
 use Dvsa\Olcs\Api\Domain\ToggleAwareTrait;
 use Dvsa\Olcs\Api\Domain\ToggleRequiredInterface;
-use Dvsa\Olcs\Api\Entity\Organisation\Organisation;
 use Dvsa\Olcs\Api\Entity\System\FeatureToggle;
 use Dvsa\Olcs\Api\Domain\Command\Result;
-use Dvsa\Olcs\Api\Domain\CommandHandler\AbstractUserCommandHandler;
+use Dvsa\Olcs\Api\Domain\CommandHandler\AbstractCommandHandler;
 use Dvsa\Olcs\Transfer\Command\CommandInterface;
 use Dvsa\Olcs\Transfer\Command\Messaging\Conversation\Enable as EnableCommand;
 
@@ -19,7 +18,7 @@ use Dvsa\Olcs\Transfer\Command\Messaging\Conversation\Enable as EnableCommand;
  *
  * @author Wade Womersley <wade.womersley@dvsa.org.uk>
  */
-final class Enable extends AbstractUserCommandHandler implements ToggleRequiredInterface
+final class Enable extends AbstractCommandHandler implements ToggleRequiredInterface
 {
     use ToggleAwareTrait;
 

--- a/test/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Disable.php
+++ b/test/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Disable.php
@@ -27,16 +27,20 @@ class Disable extends CommandHandlerTestCase
 
         $mockOrganisation = m::mock(Organisation::class);
         $mockOrganisation->shouldReceive('setIsMessagingDisabled')
+                         ->once()
                          ->with(true);
         $mockOrganisation->shouldReceive('getId')
+                         ->once()
                          ->andReturn(1);
 
         $this->repoMap[OrganisationRepo::class]
             ->shouldReceive('fetchById')
+            ->once()
             ->with(1)
             ->andReturn($mockOrganisation);
         $this->repoMap[OrganisationRepo::class]
             ->shouldReceive('save')
+            ->once()
             ->with($mockOrganisation);
 
         $result = $this->sut->handleCommand($mockCommand);

--- a/test/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Disable.php
+++ b/test/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Disable.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\OlcsTest\Api\Domain\CommandHandler\Messaging\Conversation;
+
+use Dvsa\Olcs\Api\Domain\CommandHandler\Messaging\Conversation\Disable as DisableCommandHandler;
+use Dvsa\Olcs\Api\Domain\Repository\Organisation as OrganisationRepo;
+use Dvsa\Olcs\Api\Entity\Organisation\Organisation;
+use Dvsa\Olcs\Transfer\Command\Messaging\Conversation\Disable as DisableCommand;
+use Dvsa\OlcsTest\Api\Domain\CommandHandler\CommandHandlerTestCase;
+use Mockery as m;
+
+class Disable extends CommandHandlerTestCase
+{
+    public function setUp(): void
+    {
+        $this->sut = new DisableCommandHandler();
+        $this->mockRepo(OrganisationRepo::class, OrganisationRepo::class);
+
+        parent::setUp();
+    }
+
+    public function testHandleCommand(): void
+    {
+        $mockCommand = DisableCommand::create(['organisation' => 1]);
+
+        $mockOrganisation = m::mock(Organisation::class);
+        $mockOrganisation->shouldReceive('setIsMessagingDisabled')
+                         ->with(true);
+        $mockOrganisation->shouldReceive('getId')
+                         ->andReturn(1);
+
+        $this->repoMap[OrganisationRepo::class]
+            ->shouldReceive('fetchById')
+            ->with(1)
+            ->andReturn($mockOrganisation);
+        $this->repoMap[OrganisationRepo::class]
+            ->shouldReceive('save')
+            ->with($mockOrganisation);
+
+        $result = $this->sut->handleCommand($mockCommand);
+
+        $this->assertEquals(1, $result->getId('organisation'));
+    }
+}

--- a/test/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Enable.php
+++ b/test/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Enable.php
@@ -27,16 +27,20 @@ class Enable extends CommandHandlerTestCase
 
         $mockOrganisation = m::mock(Organisation::class);
         $mockOrganisation->shouldReceive('setIsMessagingDisabled')
+                         ->once()
                          ->with(false);
         $mockOrganisation->shouldReceive('getId')
+                         ->once()
                          ->andReturn(1);
 
         $this->repoMap[OrganisationRepo::class]
             ->shouldReceive('fetchById')
+            ->once()
             ->with(1)
             ->andReturn($mockOrganisation);
         $this->repoMap[OrganisationRepo::class]
             ->shouldReceive('save')
+            ->once()
             ->with($mockOrganisation);
 
         $result = $this->sut->handleCommand($mockCommand);

--- a/test/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Enable.php
+++ b/test/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Enable.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\OlcsTest\Api\Domain\CommandHandler\Messaging\Conversation;
+
+use Dvsa\Olcs\Api\Domain\CommandHandler\Messaging\Conversation\Enable as EnableCommandHandler;
+use Dvsa\Olcs\Api\Domain\Repository\Organisation as OrganisationRepo;
+use Dvsa\Olcs\Api\Entity\Organisation\Organisation;
+use Dvsa\Olcs\Transfer\Command\Messaging\Conversation\Enable as EnableCommand;
+use Dvsa\OlcsTest\Api\Domain\CommandHandler\CommandHandlerTestCase;
+use Mockery as m;
+
+class Enable extends CommandHandlerTestCase
+{
+    public function setUp(): void
+    {
+        $this->sut = new EnableCommandHandler();
+        $this->mockRepo(OrganisationRepo::class, OrganisationRepo::class);
+
+        parent::setUp();
+    }
+
+    public function testHandleCommand(): void
+    {
+        $mockCommand = EnableCommand::create(['organisation' => 1]);
+
+        $mockOrganisation = m::mock(Organisation::class);
+        $mockOrganisation->shouldReceive('setIsMessagingDisabled')
+                         ->with(false);
+        $mockOrganisation->shouldReceive('getId')
+                         ->andReturn(1);
+
+        $this->repoMap[OrganisationRepo::class]
+            ->shouldReceive('fetchById')
+            ->with(1)
+            ->andReturn($mockOrganisation);
+        $this->repoMap[OrganisationRepo::class]
+            ->shouldReceive('save')
+            ->with($mockOrganisation);
+
+        $result = $this->sut->handleCommand($mockCommand);
+
+        $this->assertEquals(1, $result->getId('organisation'));
+    }
+}


### PR DESCRIPTION
## Description

Caseworkers can disable messaging functionality for a VOL user. This would be used in instances where the user was abusing the system or breaching terms of service.

Related issue: [VOL-4388](https://dvsa.atlassian.net/browse/VOL-4388)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
