### PR TITLE
fix: Update Messaging entites for version fix

### DIFF
--- a/module/Api/src/Entity/Messaging/AbstractMessagingContent.php
+++ b/module/Api/src/Entity/Messaging/AbstractMessagingContent.php
@@ -82,10 +82,10 @@ abstract class AbstractMessagingContent implements BundleSerializableInterface, 
      *
      * @var int
      *
-     * @ORM\Column(type="smallint", name="version", nullable=true)
+     * @ORM\Column(type="smallint", name="version", nullable=false, options={"default": 1})
      * @ORM\Version
      */
-    protected $version;
+    protected $version = 1;
 
     /**
      * Set the created by

--- a/module/Api/src/Entity/Messaging/AbstractMessagingConversation.php
+++ b/module/Api/src/Entity/Messaging/AbstractMessagingConversation.php
@@ -132,10 +132,10 @@ abstract class AbstractMessagingConversation implements BundleSerializableInterf
      *
      * @var int
      *
-     * @ORM\Column(type="smallint", name="version", nullable=true)
+     * @ORM\Column(type="smallint", name="version", nullable=false, options={"default": 1})
      * @ORM\Version
      */
-    protected $version;
+    protected $version = 1;
 
     /**
      * Set the created by

--- a/module/Api/src/Entity/Messaging/AbstractMessagingMessage.php
+++ b/module/Api/src/Entity/Messaging/AbstractMessagingMessage.php
@@ -105,10 +105,10 @@ abstract class AbstractMessagingMessage implements BundleSerializableInterface, 
      *
      * @var int
      *
-     * @ORM\Column(type="smallint", name="version", nullable=true)
+     * @ORM\Column(type="smallint", name="version", nullable=false, options={"default": 1})
      * @ORM\Version
      */
-    protected $version;
+    protected $version = 1;
 
     /**
      * Set the created by

--- a/module/Api/src/Entity/Messaging/AbstractMessagingSubject.php
+++ b/module/Api/src/Entity/Messaging/AbstractMessagingSubject.php
@@ -104,10 +104,10 @@ abstract class AbstractMessagingSubject implements BundleSerializableInterface, 
      *
      * @var int
      *
-     * @ORM\Column(type="smallint", name="version", nullable=true)
+     * @ORM\Column(type="smallint", name="version", nullable=false, options={"default": 1})
      * @ORM\Version
      */
-    protected $version;
+    protected $version = 1;
 
     /**
      * Set the category

--- a/module/Api/src/Entity/Messaging/AbstractMessagingUserMessageRead.php
+++ b/module/Api/src/Entity/Messaging/AbstractMessagingUserMessageRead.php
@@ -99,10 +99,10 @@ abstract class AbstractMessagingUserMessageRead implements BundleSerializableInt
      *
      * @var int
      *
-     * @ORM\Column(type="smallint", name="version", nullable=true)
+     * @ORM\Column(type="smallint", name="version", nullable=false, options={"default": 1})
      * @ORM\Version
      */
-    protected $version;
+    protected $version = 1;
 
     /**
      * Set the created by


### PR DESCRIPTION
## Description

This change reflects update to database for messaging tables; ensuring columns `version` cannot be `NULL` and are default to `1`.

Related issue: [VOL-4914](https://dvsa.atlassian.net/browse/VOL-4914)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
