### PR TITLE
fix: Temporary solution to ensure the messages list is never empty

### DIFF
--- a/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversation.php
+++ b/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversation.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Dvsa\Olcs\Api\Domain\QueryHandler\Messaging\Message;
 
-use Doctrine\ORM\Query;
 use Dvsa\Olcs\Api\Domain\QueryHandler\AbstractQueryHandler;
-use Dvsa\Olcs\Api\Domain\Repository\Message as MessageRepo;
 use Dvsa\Olcs\Api\Domain\ToggleAwareTrait;
 use Dvsa\Olcs\Api\Domain\ToggleRequiredInterface;
+use Dvsa\Olcs\Api\Entity\Messaging\MessagingConversation;
 use Dvsa\Olcs\Api\Entity\System\FeatureToggle;
-use Dvsa\Olcs\Transfer\Query\Messaging\Messages\ByConversation as GetConversationMessagesQuery;
 use Dvsa\Olcs\Transfer\Query\QueryInterface;
 
 class ByConversation extends AbstractQueryHandler implements ToggleRequiredInterface
@@ -31,10 +29,19 @@ class ByConversation extends AbstractQueryHandler implements ToggleRequiredInter
 
         $messages = $messageRepository->fetchPaginatedList($messagesQuery);
 
+        /*
+         * @TODO: For _some_ conversations, when sending an authenticated request (so any request from the front end,
+         * JSON serializing lastModifiedBy causes a recursion error. An unauthenticated request results in
+         * lastModifiedBy always being null.
+         */
+        /** @var MessagingConversation $conversation */
+        $conversation = $this->getRepo('Conversation')->fetchById($query->getConversation());
+        $conversation->setLastModifiedBy(null);
+
         return [
             'result' => $messages,
             'count' => $messageRepository->fetchPaginatedCount($messagesQuery),
-            'conversation' => $this->getRepo('Conversation')->fetchById($query->getConversation()),
+            'conversation' => $conversation,
         ];
     }
 }


### PR DESCRIPTION
## Description

Temporarily unblock empty conversations.

Related issue: [VOL-4917](https://dvsa.atlassian.net/browse/VOL-4917)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
