### PR TITLE
fix: create conversation command specified licence id for conversation

### DIFF
--- a/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Create.php
+++ b/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Create.php
@@ -70,6 +70,7 @@ final class Create extends AbstractCommandHandler implements ToggleAwareInterfac
         $result = new Result();
 
         $result->addId('conversation', $conversation->getId())->addMessage('Conversation added');
+        $result->addId('licence', $licenceId);
 
         $result->merge($createTaskResult);
         $result->merge($createMessageResult);

--- a/test/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Create.php
+++ b/test/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Create.php
@@ -190,6 +190,6 @@ class Create extends CommandHandlerTestCase
             (new Result())->addId('message', 5)
         );
 
-        $this->sut->handleCommand($command)->toArray();
+        $this->sut->handleCommand($command);
     }
 }


### PR DESCRIPTION
## Description

Additional fix for https://github.com/dvsa/olcs-backend/pull/47 ensuring licence id is specified for created conversation for internal redirect assist.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
