### PR TITLE
fix: Prevent recursion on message list

### DIFF
--- a/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversation.php
+++ b/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversation.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Dvsa\Olcs\Api\Domain\QueryHandler\Messaging\Message;
 
 use Dvsa\Olcs\Api\Domain\QueryHandler\AbstractQueryHandler;
+use Dvsa\Olcs\Api\Domain\Repository\Conversation;
+use Dvsa\Olcs\Api\Domain\Repository\Message;
 use Dvsa\Olcs\Api\Domain\ToggleAwareTrait;
 use Dvsa\Olcs\Api\Domain\ToggleRequiredInterface;
 use Dvsa\Olcs\Api\Entity\Messaging\MessagingConversation;
@@ -17,11 +19,11 @@ class ByConversation extends AbstractQueryHandler implements ToggleRequiredInter
 
     protected array $toggleConfig = [FeatureToggle::MESSAGING];
 
-    protected $extraRepos = ['Conversation', 'Message', 'MessageContent'];
+    protected $extraRepos = [Message::class, Conversation::class];
 
     public function handleQuery(QueryInterface $query)
     {
-        $messageRepository = $this->getRepo('Message');
+        $messageRepository = $this->getRepo(Message::class);
 
         $messageQueryBuilder = $messageRepository->getBaseMessageListWithContentQuery($query);
 
@@ -30,7 +32,7 @@ class ByConversation extends AbstractQueryHandler implements ToggleRequiredInter
         $messages = $messageRepository->fetchPaginatedList($messagesQuery);
 
         /** @var MessagingConversation $conversation */
-        $conversation = $this->getRepo('Conversation')->fetchById($query->getConversation());
+        $conversation = $this->getRepo(Conversation::class)->fetchById($query->getConversation());
 
         return [
             'result'       => $messages,

--- a/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversation.php
+++ b/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversation.php
@@ -29,19 +29,13 @@ class ByConversation extends AbstractQueryHandler implements ToggleRequiredInter
 
         $messages = $messageRepository->fetchPaginatedList($messagesQuery);
 
-        /*
-         * For _some_ conversations, when sending an authenticated request (so any request from the front end,
-         * JSON serializing lastModifiedBy causes a recursion error. An unauthenticated request results in
-         * lastModifiedBy always being null.
-         */
         /** @var MessagingConversation $conversation */
         $conversation = $this->getRepo('Conversation')->fetchById($query->getConversation());
-        $conversation->setLastModifiedBy(null);
 
         return [
-            'result' => $messages,
-            'count' => $messageRepository->fetchPaginatedCount($messagesQuery),
-            'conversation' => $conversation,
+            'result'       => $messages,
+            'count'        => $messageRepository->fetchPaginatedCount($messagesQuery),
+            'conversation' => $conversation->serialize(),
         ];
     }
 }

--- a/test/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversationTest.php
+++ b/test/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversationTest.php
@@ -18,8 +18,8 @@ class ByConversationTest extends QueryHandlerTestCase
     public function setUp(): void
     {
         $this->sut = new ByConversation();
-        $this->mockRepo('Conversation', Repository\Conversation::class);
-        $this->mockRepo('Message', Repository\Message::class);
+        $this->mockRepo(Repository\Conversation::class, Repository\Conversation::class);
+        $this->mockRepo(Repository\Message::class, Repository\Message::class);
 
         $this->mockedSmServices = ['SectionAccessService' => m::mock(), AuthorizationService::class => m::mock(AuthorizationService::class)->shouldReceive('isGranted')->with(Permission::SELFSERVE_USER, null)->andReturn(true)->shouldReceive('isGranted')->with(Permission::INTERNAL_USER, null)->andReturn(false)->getMock(),];
 
@@ -48,11 +48,11 @@ class ByConversationTest extends QueryHandlerTestCase
         );
         $conversation = new MessagingConversation();
         $mockQb = m::mock(QueryBuilder::class);
-        $this->repoMap['Message']->shouldReceive('getBaseMessageListWithContentQuery')->andReturn($mockQb);
-        $this->repoMap['Message']->shouldReceive('filterByConversationId')->andReturn($mockQb);
-        $this->repoMap['Message']->shouldReceive('fetchPaginatedList')->with($mockQb)->once()->andReturn($messages);
-        $this->repoMap['Message']->shouldReceive('fetchPaginatedCount')->with($mockQb)->once()->andReturn(10);
-        $this->repoMap['Conversation']->shouldReceive('fetchById')->with(1)->once()->andReturn($conversation);
+        $this->repoMap[Repository\Message::class]->shouldReceive('getBaseMessageListWithContentQuery')->andReturn($mockQb);
+        $this->repoMap[Repository\Message::class]->shouldReceive('filterByConversationId')->andReturn($mockQb);
+        $this->repoMap[Repository\Message::class]->shouldReceive('fetchPaginatedList')->with($mockQb)->once()->andReturn($messages);
+        $this->repoMap[Repository\Message::class]->shouldReceive('fetchPaginatedCount')->with($mockQb)->once()->andReturn(10);
+        $this->repoMap[Repository\Conversation::class]->shouldReceive('fetchById')->with(1)->once()->andReturn($conversation);
 
         $result = $this->sut->handleQuery($query);
 


### PR DESCRIPTION
## Description

Call serialize() on the conversation object to prevent recursion.

Related issue: [VOL-4917](https://dvsa.atlassian.net/browse/VOL-4917)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
