### PR TITLE
fix: VOL-4944 update continuation not sought to use bound params and Doctrine Result class

### DIFF
--- a/module/Api/src/Domain/Repository/Queue.php
+++ b/module/Api/src/Domain/Repository/Queue.php
@@ -80,19 +80,18 @@ SQL;
             $query .= "(:status{$i}, :type{$i}, :options{$i}), ";
         }
         $query = trim($query, ', ');
+        $stmt = $conn->prepare($query);
 
-        $params = [];
         $i = 1;
         foreach ($licences as $licence) {
-            $params['status' . $i] = Entity::STATUS_QUEUED;
-            $params['type' . $i] = Entity::TYPE_CNS;
-            $params['options' . $i] = '{"id":' . $licence['id'] . ',"version":' . $licence['version'] . '}';
+            $stmt->bindValue('status' . $i, Entity::STATUS_QUEUED);
+            $stmt->bindValue('type' . $i, Entity::TYPE_CNS);
+            $stmt->bindValue('options' . $i, '{"id":' . $licence['id'] . ',"version":' . $licence['version'] . '}');
             $i++;
         }
 
-        $stmt = $conn->prepare($query);
-        $stmt->execute($params);
-        return $stmt->rowCount();
+        $result = $stmt->executeQuery();
+        return $result->rowCount();
     }
 
     /**

--- a/test/module/Api/src/Domain/Repository/QueueTest.php
+++ b/test/module/Api/src/Domain/Repository/QueueTest.php
@@ -8,6 +8,9 @@
 
 namespace Dvsa\OlcsTest\Api\Domain\Repository;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Statement;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Dvsa\Olcs\Api\Domain\Repository\Queue as QueueRepo;
@@ -149,35 +152,28 @@ class QueueTest extends RepositoryTestCase
         $query = 'INSERT INTO `queue` (`status`, `type`, `options`) VALUES '
             . '(:status1, :type1, :options1), (:status2, :type2, :options2)';
 
-        $params = [
-            'status1' => QueueEntity::STATUS_QUEUED,
-            'type1' => QueueEntity::TYPE_CNS,
-            'options1' => $options1,
-            'status2' => QueueEntity::STATUS_QUEUED,
-            'type2' => QueueEntity::TYPE_CNS,
-            'options2' => $options2
-        ];
+        $queryResult = m::mock(Result::class);
+        $queryResult->expects('rowCount')
+            ->withNoArgs()
+            ->andReturn(2);
 
-        $mockStatement = m::mock()
-            ->shouldReceive('execute')
-            ->with($params)
-            ->once()
-            ->shouldReceive('rowCount')
-            ->andReturn(2)
-            ->once()
-            ->getMock();
+        $mockStatement = m::mock(Statement::class);
+        $mockStatement ->expects('executeQuery')
+            ->withNoArgs()
+            ->andReturn($queryResult);
+        $mockStatement->expects('bindValue')->with('status1', QueueEntity::STATUS_QUEUED);
+        $mockStatement->expects('bindValue')->with('type1', QueueEntity::TYPE_CNS);
+        $mockStatement->expects('bindValue')->with('options1', $options1);
+        $mockStatement->expects('bindValue')->with('status2', QueueEntity::STATUS_QUEUED);
+        $mockStatement->expects('bindValue')->with('type2', QueueEntity::TYPE_CNS);
+        $mockStatement->expects('bindValue')->with('options2', $options2);
 
-        $mockConnection = m::mock()
-            ->shouldReceive('prepare')
+        $mockConnection = m::mock(Connection::class);
+        $mockConnection->expects('prepare')
             ->with($query)
-            ->andReturn($mockStatement)
-            ->once()
-            ->getMock();
+            ->andReturn($mockStatement);
 
-        $this->em->shouldReceive('getConnection')
-            ->andReturn($mockConnection)
-            ->once()
-            ->getMock();
+        $this->em->expects('getConnection')->withNoArgs()->andReturn($mockConnection);
 
         $licences = [
             ['id' => 1, 'version' => 2],


### PR DESCRIPTION
## Description

Continuation not sought batch job had been broken by the Doctrine upgrade. This fixes that and also introduces bound params.

Related issue: [VOL-4944](https://dvsa.atlassian.net/browse/VOL-4944)
