### PR TITLE
fix: flag-urgent-tasks batch job getCalls and deprecated doctrine method

### DIFF
--- a/module/Api/src/Domain/Repository/Task.php
+++ b/module/Api/src/Domain/Repository/Task.php
@@ -139,10 +139,10 @@ class Task extends AbstractRepository
     {
         /** @var \Doctrine\DBAL\Result $stmt */
         $stmt = $this->getDbQueryManager()
-            ->get('Task/FlagUrgentTasks')
+            ->get('Task\FlagUrgentTasks')
             ->execute();
 
-        return $stmt->fetchColumn(0);
+        return (int) $stmt->fetchOne();
     }
 
     /**

--- a/test/module/Api/src/Domain/Repository/TaskTest.php
+++ b/test/module/Api/src/Domain/Repository/TaskTest.php
@@ -143,13 +143,13 @@ class TaskTest extends RepositoryTestCase
     public function testFlagUrgentsTasks()
     {
         $queryResponse = m::mock();
-        $queryResponse->shouldReceive('fetchColumn')->with(0)->once()->andReturn(65);
+        $queryResponse->shouldReceive('fetchOne')->once()->andReturn(65);
 
         $query = m::mock();
         $query->shouldReceive('execute')->once()->with()->andReturn($queryResponse);
 
         $this->dbQueryService->shouldReceive('get')
-            ->with('Task/FlagUrgentTasks')
+            ->with('Task\FlagUrgentTasks')
             ->andReturn($query);
 
         $result = $this->sut->flagUrgentsTasks();


### PR DESCRIPTION
## Description

fix up flag-urgent-tasks batch job - now works locally again.

Related issue: [4963](https://dvsa.atlassian.net/browse/VOL-4963)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
