### PR TITLE
fix: Add missing messaging flag for backend.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6350,12 +6350,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dvsa/olcs-transfer.git",
-                "reference": "e2727d8e365a41f2b6093282a96800794cbcc8c3"
+                "reference": "48253e03297ea382792f1ac5c7f84b9a5839c916"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dvsa/olcs-transfer/zipball/e2727d8e365a41f2b6093282a96800794cbcc8c3",
-                "reference": "e2727d8e365a41f2b6093282a96800794cbcc8c3",
+                "url": "https://api.github.com/repos/dvsa/olcs-transfer/zipball/48253e03297ea382792f1ac5c7f84b9a5839c916",
+                "reference": "48253e03297ea382792f1ac5c7f84b9a5839c916",
                 "shasum": ""
             },
             "require": {
@@ -6397,7 +6397,7 @@
             "support": {
                 "source": "https://github.com/dvsa/olcs-transfer/tree/project/messaging"
             },
-            "time": "2024-02-06T15:11:55+00:00"
+            "time": "2024-02-09T14:53:43+00:00"
         },
         {
             "name": "olcs/olcs-utils",

--- a/module/Api/src/Domain/CommandHandler/Task/CreateTask.php
+++ b/module/Api/src/Domain/CommandHandler/Task/CreateTask.php
@@ -420,7 +420,7 @@ final class CreateTask extends AbstractCommandHandler
         $task->setDescription($command->getDescription());
         $task->setIsClosed($command->getIsClosed());
         $task->setUrgent($command->getUrgent());
-        $task->setMessaging($command->getMessaging());
+        $task->setMessaging(in_array($command->getMessaging(), ['Y', true]));
 
         $task->setLastModifiedOn(new DateTime());
 


### PR DESCRIPTION
## Description

Last TM letter batch job erroring due to CreateTask::getMessaging() method

Related issue: [VOL-4975](https://dvsa.atlassian.net/browse/VOL-4975)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
