### PR TITLE
feat: VOL-4994 bus reg expiry batch job now returns number of expired records

### DIFF
--- a/module/Api/src/Domain/Repository/Bus.php
+++ b/module/Api/src/Domain/Repository/Bus.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * Bus
- */
-
 namespace Dvsa\Olcs\Api\Domain\Repository;
 
 use Dvsa\Olcs\Api\Entity\Bus\BusReg as Entity;
@@ -15,9 +11,6 @@ use Doctrine\ORM\QueryBuilder;
 use Dvsa\Olcs\Transfer\Query\QueryInterface;
 use Doctrine\ORM\Query\Expr\Join;
 
-/**
- * Bus
- */
 class Bus extends AbstractRepository
 {
     protected $entity = Entity::class;
@@ -188,11 +181,9 @@ class Bus extends AbstractRepository
 
     /**
      * expire all bus registrations that have reached their end date
-     *
-     * @return void
      */
-    public function expireRegistrations()
+    public function expireRegistrations(): int
     {
-        $this->getDbQueryManager()->get(ExpireQuery::class)->execute([]);
+        return $this->getDbQueryManager()->get(ExpireQuery::class)->execute([])->rowCount();
     }
 }

--- a/module/Cli/src/Domain/CommandHandler/Bus/Expire.php
+++ b/module/Cli/src/Domain/CommandHandler/Bus/Expire.php
@@ -31,8 +31,8 @@ final class Expire extends AbstractCommandHandler implements TransactionedInterf
 
         /** @var BusRepo $repo */
         $repo = $this->getRepo();
-        $repo->expireRegistrations();
-        $result->addMessage('registrations have been expired');
+        $rowCount = $repo->expireRegistrations();
+        $result->addMessage($rowCount . ' registrations have been expired');
 
         return $result;
     }

--- a/test/module/Api/src/Domain/Repository/BusTest.php
+++ b/test/module/Api/src/Domain/Repository/BusTest.php
@@ -8,6 +8,7 @@
 
 namespace Dvsa\OlcsTest\Api\Domain\Repository;
 
+use Doctrine\DBAL\Result;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\DBAL\LockMode;
@@ -437,7 +438,11 @@ class BusTest extends RepositoryTestCase
 
     public function testExpireBusRegistrations()
     {
-        $this->expectQueryWithData(ExpireQuery::class, []);
-        $this->sut->expireRegistrations();
+        $rowCount = 555;
+        $mockResult = m::mock(Result::class);
+        $mockResult->expects('rowCount')->withNoArgs()->andReturn($rowCount);
+
+        $this->expectQueryWithData(ExpireQuery::class, [], [], $mockResult);
+        $this->assertEquals($rowCount, $this->sut->expireRegistrations());
     }
 }

--- a/test/module/Cli/src/Domain/CommandHandler/Bus/ExpireTest.php
+++ b/test/module/Cli/src/Domain/CommandHandler/Bus/ExpireTest.php
@@ -29,10 +29,11 @@ class ExpireTest extends CommandHandlerTestCase
      */
     public function testHandleCommand()
     {
-        $this->repoMap['Bus']->shouldReceive('expireRegistrations')->withNoArgs();
+        $numExpired = 666;
+        $this->repoMap['Bus']->expects('expireRegistrations')->withNoArgs()->andReturn($numExpired);
         $result = $this->sut->handleCommand(ExpireBusCmd::create([]));
 
-        $messages = [0 => 'registrations have been expired'];
+        $messages = [0 => $numExpired . ' registrations have been expired'];
         $this->assertEquals($messages, $result->getMessages());
     }
 }


### PR DESCRIPTION
## Description

Bus Reg expiry batch job didn't previously display how many registrations had been expired. This adds that in, to allow a better idea at a glance of whether the job is behaving correctly.

Related issue: [VOL-4994](https://dvsa.atlassian.net/browse/VOL-4994)
