### PR TITLE
fix: Use licence instead of application for sending email

### DIFF
--- a/module/Api/src/Domain/CommandHandler/Email/SendNewMessageNotificationToOperators.php
+++ b/module/Api/src/Domain/CommandHandler/Email/SendNewMessageNotificationToOperators.php
@@ -9,29 +9,29 @@ use Dvsa\Olcs\Api\Domain\Command\Result;
 use Dvsa\Olcs\Api\Domain\Command\Task\CreateTask;
 use Dvsa\Olcs\Api\Domain\EmailAwareInterface;
 use Dvsa\Olcs\Api\Domain\Exception\MissingEmailException;
-use Dvsa\Olcs\Api\Domain\Repository\Application as ApplicationRepo;
-use Dvsa\Olcs\Api\Entity\Application\Application as ApplicationEntity;
+use Dvsa\Olcs\Api\Domain\Repository\Licence as LicenceRepo;
+use Dvsa\Olcs\Api\Entity\Licence\Licence as LicenceEntity;
 use Dvsa\Olcs\Api\Entity\System\Category;
 
 final class SendNewMessageNotificationToOperators extends AbstractEmailHandler implements EmailAwareInterface
 {
-    protected $repoServiceName = ApplicationRepo::class;
+    protected $repoServiceName = LicenceRepo::class;
     protected $template = 'messaging-new-message-operator';
     protected $subject = 'email.new-message-for-operator.subject';
 
-    /** @param ApplicationEntity $recordObject */
+    /** @param LicenceEntity $recordObject */
     protected function getRecipients($recordObject): array
     {
-        return $this->organisationRecipients($recordObject->getLicence()->getOrganisation());
+        return $this->organisationRecipients($recordObject->getOrganisation());
     }
 
-    /** @param ApplicationEntity $recordObject */
+    /** @param LicenceEntity $recordObject */
     protected function getTranslateToWelsh($recordObject)
     {
-        return $recordObject->getLicence()->getTranslateToWelsh();
+        return $recordObject->getTranslateToWelsh();
     }
 
-    /** @param ApplicationEntity $recordObject */
+    /** @param LicenceEntity $recordObject */
     protected function createMissingEmailTask($recordObject, Result $result, MissingEmailException $exception): Result
     {
         $taskData = [
@@ -40,11 +40,10 @@ final class SendNewMessageNotificationToOperators extends AbstractEmailHandler i
             'description'     => sprintf(
                 'Unable to send email - no organisation recipients found for Org: %s' .
                 ' - Please update the organisation admin user contacts to ensure at least one has a valid email address.',
-                $recordObject->getLicence()->getOrganisation()->getName(),
+                $recordObject->getOrganisation()->getName(),
             ),
             'actionDate'      => (new DateTimeImmutable())->format('Y-m-d'),
-            'licence'         => $recordObject->getLicence()->getId(),
-            'irhpApplication' => $recordObject->getId(),
+            'licence'         => $recordObject->getId(),
             'urgent'          => 'Y',
         ];
 

--- a/module/Api/src/Domain/CommandHandler/Messaging/Message/Create.php
+++ b/module/Api/src/Domain/CommandHandler/Messaging/Message/Create.php
@@ -54,14 +54,19 @@ final class Create extends AbstractCommandHandler implements ToggleRequiredInter
         $result = new Result();
 
         $result->addId('message', $message->getId())
-            ->addMessage('Message created')
-            ->addId('messageContent', $message->getMessagingContent()->getId())
-            ->addMessage('MessageContent created')
-            ->addId('messageConversation', $message->getMessagingConversation()->getId())
-            ->addMessage('Message added to conversation')
-            ->addId('task', $updatedTask->getId())
-            ->addMessage(sprintf('Updated task action date: %s', $updatedTask->getActionDate()->format(DateTimeInterface::ATOM)))
-            ->addMessage(sprintf('Updated task description: %s', $updatedTask->getDescription()));
+               ->addMessage('Message created')
+               ->addId('messageContent', $message->getMessagingContent()->getId())
+               ->addMessage('MessageContent created')
+               ->addId('messageConversation', $message->getMessagingConversation()->getId())
+               ->addMessage('Message added to conversation')
+               ->addId('task', $updatedTask->getId())
+               ->addMessage(
+                   sprintf(
+                       'Updated task action date: %s',
+                       $updatedTask->getActionDate()->format(DateTimeInterface::ATOM),
+                   ),
+               )
+               ->addMessage(sprintf('Updated task description: %s', $updatedTask->getDescription()));
 
         if ($sendEmailResult !== null) {
             $result->merge($sendEmailResult);
@@ -104,8 +109,9 @@ final class Create extends AbstractCommandHandler implements ToggleRequiredInter
         return $entity;
     }
 
-    private function createMessageEntity(MessagingConversation $messagingConversation, MessagingContent $messagingContent): MessagingMessage
-    {
+    private function createMessageEntity(
+        MessagingConversation $messagingConversation, MessagingContent $messagingContent
+    ): MessagingMessage {
         $entity = new MessagingMessage();
         $entity->setMessagingConversation($messagingConversation)->setMessagingContent($messagingContent);
         return $entity;
@@ -168,9 +174,9 @@ final class Create extends AbstractCommandHandler implements ToggleRequiredInter
         return $this->handleSideEffect(
             SendNewMessageNotificationToOperators::create(
                 [
-                    'id' => $conversation->getTask()->getApplication()->getId(),
-                ]
-            )
+                    'id' => $conversation->getTask()->getLicence()->getId(),
+                ],
+            ),
         );
     }
 }


### PR DESCRIPTION
## Description

In case there is no application against a task, use the licence instead to send the email notification.

Related issue: [VOL-4528](https://dvsa.atlassian.net/browse/VOL-4528)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
