### PR TITLE
chore: revert composer.json/lock to use non-messaging project branches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "league/flysystem-webdav": "1.0.10",
         "monolog/monolog": "^2.9",
         "olcs/olcs-logging": "^5.0.0",
-        "olcs/olcs-transfer": "dev-project/messaging",
+        "olcs/olcs-transfer": "^5.0.0",
         "olcs/olcs-utils": "^5.0.0",
         "olcs/olcs-xmltools": "^5.0.0",
         "oro/doctrine-extensions": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "631dbc529ed4ffb3c429626d3098dd7f",
+    "content-hash": "6d0e7eb2a9ce23340fc16f7205d82a57",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -6346,16 +6346,16 @@
         },
         {
             "name": "olcs/olcs-transfer",
-            "version": "dev-project/messaging",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dvsa/olcs-transfer.git",
-                "reference": "48253e03297ea382792f1ac5c7f84b9a5839c916"
+                "reference": "b1fe910e1dafbf495367d16fe1953cf1aa9f88b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dvsa/olcs-transfer/zipball/48253e03297ea382792f1ac5c7f84b9a5839c916",
-                "reference": "48253e03297ea382792f1ac5c7f84b9a5839c916",
+                "url": "https://api.github.com/repos/dvsa/olcs-transfer/zipball/b1fe910e1dafbf495367d16fe1953cf1aa9f88b6",
+                "reference": "b1fe910e1dafbf495367d16fe1953cf1aa9f88b6",
                 "shasum": ""
             },
             "require": {
@@ -6395,9 +6395,9 @@
             "notification-url": "https://packagist.org/downloads/",
             "description": "OLCS Transfer",
             "support": {
-                "source": "https://github.com/dvsa/olcs-transfer/tree/project/messaging"
+                "source": "https://github.com/dvsa/olcs-transfer/tree/v5.1.0"
             },
-            "time": "2024-02-09T14:53:43+00:00"
+            "time": "2024-02-16T10:21:39+00:00"
         },
         {
             "name": "olcs/olcs-utils",
@@ -11951,9 +11951,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "olcs/olcs-transfer": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -11965,5 +11963,5 @@
     "platform-overrides": {
         "ext-redis": "4.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
## Description

chore: revert composer.json/lock to use non-messaging project branches
## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
