### PR TITLE
fix: Check for correlation ID for uploads being null

### DIFF
--- a/module/Api/src/Domain/CommandHandler/Messaging/Message/Create.php
+++ b/module/Api/src/Domain/CommandHandler/Messaging/Message/Create.php
@@ -56,7 +56,7 @@ final class Create extends AbstractCommandHandler implements ToggleRequiredInter
         $message = $this->generateAndSaveMessage($command);
         $updatedTask = $this->updateTaskDescriptionAndActionDate($command);
         $sendEmailResult = $this->sendEmail($command);
-        
+
         if ($command->getCorrelationId() !== null) {
             $this->assignUploadsToMessage($message, $command->getCorrelationId());
         }

--- a/module/Api/src/Domain/CommandHandler/Messaging/Message/Create.php
+++ b/module/Api/src/Domain/CommandHandler/Messaging/Message/Create.php
@@ -56,7 +56,10 @@ final class Create extends AbstractCommandHandler implements ToggleRequiredInter
         $message = $this->generateAndSaveMessage($command);
         $updatedTask = $this->updateTaskDescriptionAndActionDate($command);
         $sendEmailResult = $this->sendEmail($command);
-        $this->assignUploadsToMessage($message, $command->getCorrelationId());
+        
+        if ($command->getCorrelationId() !== null) {
+            $this->assignUploadsToMessage($message, $command->getCorrelationId());
+        }
 
         $result = new Result();
 


### PR DESCRIPTION
## Description

When a new conversation is created, the correlation ID is null due to no uploads.

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
