### PR TITLE
fix: Slow join on documents to messages.

### DIFF
--- a/module/Api/src/Domain/QueryHandler/Messaging/Conversations/ByLicence.php
+++ b/module/Api/src/Domain/QueryHandler/Messaging/Conversations/ByLicence.php
@@ -32,7 +32,7 @@ class ByLicence extends AbstractConversationQueryHandler implements ToggleRequir
             $unreadMessageCount = $this->getUnreadMessageCountForUser($value);
             $conversations[$key]['userContextUnreadCount'] = $unreadMessageCount;
             $conversations[$key]['userContextStatus'] = $this->stringifyMessageStatusForUser($value, $unreadMessageCount);
-            $conversations[$key]['latestMessage'] = $this->getLatestMessageMetadata($value['id']);
+            $conversations[$key]['latestMessage'] = $this->getLatestMessageMetadata((int)$value['id']);
         }
 
         $conversations = $this->orderResultPrioritisingNewMessages($conversations);
@@ -51,17 +51,14 @@ class ByLicence extends AbstractConversationQueryHandler implements ToggleRequir
         return count($results);
     }
 
-    private function getLatestMessageMetadata($conversationId): array
+    private function getLatestMessageMetadata(int $conversationId): array
     {
         $messageRepository = $this->getRepo('Message');
-        assert($messageRepository instanceof MessageRepo);
         return $messageRepository->getLastMessageByConversationId($conversationId);
     }
 
     private function getRepository(): ConversationRepo
     {
-        $conversationRepository = $this->getRepo('Conversation');
-        assert($conversationRepository instanceof ConversationRepo);
-        return $conversationRepository;
+        return $this->getRepo('Conversation');
     }
 }

--- a/module/Api/src/Domain/QueryHandler/Messaging/Conversations/ByOrganisation.php
+++ b/module/Api/src/Domain/QueryHandler/Messaging/Conversations/ByOrganisation.php
@@ -34,7 +34,7 @@ class ByOrganisation extends AbstractConversationQueryHandler implements ToggleR
             );
             $conversations[$key]['userContextUnreadCount'] = $unreadMessageCount;
             $conversations[$key]['userContextStatus'] = $this->stringifyMessageStatusForUser($value, $unreadMessageCount);
-            $conversations[$key]['latestMessage'] = $messageRepository->getLastMessageByConversationId($value['id']);
+            $conversations[$key]['latestMessage'] = $messageRepository->getLastMessageByConversationId((int)$value['id']);
         }
 
         $conversations = $this->orderResultPrioritisingNewMessages($conversations);

--- a/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversation.php
+++ b/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversation.php
@@ -35,7 +35,7 @@ class ByConversation extends AbstractQueryHandler implements ToggleRequiredInter
 
         $messageQueryBuilder = $messageRepository->getBaseMessageListWithContentQuery($query);
 
-        $messagesQuery = $messageRepository->filterByConversationId($messageQueryBuilder, $query->getConversation());
+        $messagesQuery = $messageRepository->filterByConversationId($messageQueryBuilder, (int)$query->getConversation());
 
         $messages = $messageRepository->fetchPaginatedList($messagesQuery);
 

--- a/module/Api/src/Domain/Repository/Message.php
+++ b/module/Api/src/Domain/Repository/Message.php
@@ -44,16 +44,16 @@ class Message extends AbstractRepository
         return $qb;
     }
 
-    public function filterByConversationId(QueryBuilder $qb, $conversationId): QueryBuilder
+    public function filterByConversationId(QueryBuilder $qb, int $conversationId): QueryBuilder
     {
         $qb
             ->andWhere($qb->expr()->eq($this->alias . '.messagingConversation', ':messagingConversation'))
-            ->setParameter('messagingConversation', (int)$conversationId);
+            ->setParameter('messagingConversation', $conversationId);
 
         return $qb;
     }
 
-    public function getLastMessageByConversationId($conversationId): array
+    public function getLastMessageByConversationId(int $conversationId): array
     {
         $qb = $this->createQueryBuilder();
         $qb = $this->filterByConversationId($qb, $conversationId);

--- a/module/Api/src/Domain/Repository/Message.php
+++ b/module/Api/src/Domain/Repository/Message.php
@@ -2,6 +2,7 @@
 
 namespace Dvsa\Olcs\Api\Domain\Repository;
 
+use Doctrine\DBAL\ParameterType;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Dvsa\Olcs\Api\Entity\Messaging\MessagingMessage as Entity;
@@ -30,8 +31,15 @@ class Message extends AbstractRepository
 
         $this->getQueryBuilder()->modifyQuery($qb)
             ->with('messagingContent')
-            ->with('documents')
             ->withCreatedByWithTeam();
+
+        $qb->leftJoin(
+            $this->alias . '.documents',
+            'd',
+            Query\Expr\Join::WITH,
+            $this->alias . '.messagingConversation = d.messagingConversation'
+        );
+        $qb->addSelect('d');
 
         return $qb;
     }
@@ -40,7 +48,7 @@ class Message extends AbstractRepository
     {
         $qb
             ->andWhere($qb->expr()->eq($this->alias . '.messagingConversation', ':messagingConversation'))
-            ->setParameter('messagingConversation', $conversationId);
+            ->setParameter('messagingConversation', (int)$conversationId);
 
         return $qb;
     }


### PR DESCRIPTION
## Description

Use both conversation and message on join to avoid lack of index use (MySQL not picking conversation index).

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
