### PR TITLE
feat: Update SendInspectionRequest to use sysParam for to: email address

### DIFF
--- a/module/Api/src/Entity/System/SystemParameter.php
+++ b/module/Api/src/Entity/System/SystemParameter.php
@@ -38,4 +38,6 @@ class SystemParameter extends AbstractSystemParameter
     public const DATA_SEPARATION_TEAMS_EXEMPT = 'DATA_SEPARATION_TEAMS_EXEMPT';
     public const LAST_TM_NI_TASK_OWNER = 'LAST_TM_NI_TASK_OWNER';
     public const LAST_TM_GB_TASK_OWNER = 'LAST_TM_GB_TASK_OWNER';
+    public const NEW_OP_EMAIL_GB = 'NEW_OP_EMAIL_GB';
+    public const NEW_OP_EMAIL_NI = 'NEW_OP_EMAIL_NI';
 }


### PR DESCRIPTION
## Description

Change SendInspectionRequest command handler to use System Parameter value for GB and NI EMS emails, replacing the use of 14 different emails from the DB.

Related issue: [VOL-5011](https://dvsa.atlassian.net/browse/VOL-5011)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
