### PR TITLE
feat: Show message attachments in the internal document list

### DIFF
--- a/module/Api/src/Domain/CommandHandler/Messaging/Message/Create.php
+++ b/module/Api/src/Domain/CommandHandler/Messaging/Message/Create.php
@@ -210,6 +210,8 @@ final class Create extends AbstractCommandHandler implements ToggleRequiredInter
             }
 
             $doc->setMessagingMessage($message);
+            $doc->setLicence($message->getMessagingConversation()->getRelatedLicence());
+            $doc->setApplication($message->getMessagingConversation()->getTask()->getApplication());
             $docRepo->saveOnFlush($doc);
         }
 


### PR DESCRIPTION
## Description

Add message attachments to the document list in internal.

Related issue: [VOL-5118](https://dvsa.atlassian.net/browse/VOL-5118)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
