### PR TITLE
fix: Change continuation to conversation in the email body

### DIFF
--- a/module/Email/view/email/cy_GB/html/licensing-information-conversation.phtml
+++ b/module/Email/view/email/cy_GB/html/licensing-information-conversation.phtml
@@ -1,6 +1,6 @@
 <p>Annwyl weithredwr,</p>
 
-<p><?php echo $this->translate('email.licensing-information.continuation.body'); ?></p>
+<p><?php echo $this->translate('email.licensing-information.conversation.body'); ?></p>
 
 <p>
     <a href="<?php echo $this->escapeHtml($this->url); ?>">Mewngofnodi i'ch cyfrif</a>

--- a/module/Email/view/email/cy_GB/plain/licensing-information-conversation.phtml
+++ b/module/Email/view/email/cy_GB/plain/licensing-information-conversation.phtml
@@ -1,5 +1,5 @@
 Annwyl weithredwr,
 
-<?php echo $this->translate('email.licensing-information.continuation.body'); ?>
+<?php echo $this->translate('email.licensing-information.conversation.body'); ?>
 
 Mewngofnodi i'ch cyfrif <?php echo $this->url; ?>.

--- a/module/Email/view/email/en_GB/html/licensing-information-conversation.phtml
+++ b/module/Email/view/email/en_GB/html/licensing-information-conversation.phtml
@@ -1,6 +1,6 @@
 <p>Dear operator,</p>
 
-<p><?php echo $this->translate('email.licensing-information.continuation.body'); ?></p>
+<p><?php echo $this->translate('email.licensing-information.conversation.body'); ?></p>
 
 <p>
   <a href="<?php echo $this->escapeHtml($this->url); ?>">Sign in to your account</a>

--- a/module/Email/view/email/en_GB/plain/licensing-information-conversation.phtml
+++ b/module/Email/view/email/en_GB/plain/licensing-information-conversation.phtml
@@ -1,5 +1,5 @@
 Dear operator,
 
-<?php echo $this->translate('email.licensing-information.continuation.body'); ?>
+<?php echo $this->translate('email.licensing-information.conversation.body'); ?>
 
 Sign in to your account at <?php echo $this->url; ?>.


### PR DESCRIPTION
## Description

Change the word continuation to conversation.

Related issue: [VOL-5081](https://dvsa.atlassian.net/browse/VOL-5081)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
