### PR TITLE
feat: Message footer showing operator first read

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7eaa8c3708f6b0fbc5e6cbcd283d46b9",
+    "content-hash": "081dc4ba17b1de2c863e53db50ff9012",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -6347,16 +6347,16 @@
         },
         {
             "name": "olcs/olcs-transfer",
-            "version": "v6.5.0",
+            "version": "v6.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dvsa/olcs-transfer.git",
-                "reference": "1bcbf1228944bdc15eb59da03af6206f00983f25"
+                "reference": "95142e4af09b8625710f9998441e219ed5210b69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dvsa/olcs-transfer/zipball/1bcbf1228944bdc15eb59da03af6206f00983f25",
-                "reference": "1bcbf1228944bdc15eb59da03af6206f00983f25",
+                "url": "https://api.github.com/repos/dvsa/olcs-transfer/zipball/95142e4af09b8625710f9998441e219ed5210b69",
+                "reference": "95142e4af09b8625710f9998441e219ed5210b69",
                 "shasum": ""
             },
             "require": {
@@ -6397,9 +6397,9 @@
             "notification-url": "https://packagist.org/downloads/",
             "description": "OLCS Transfer",
             "support": {
-                "source": "https://github.com/dvsa/olcs-transfer/tree/v6.5.0"
+                "source": "https://github.com/dvsa/olcs-transfer/tree/v6.6.0"
             },
-            "time": "2024-03-05T16:35:41+00:00"
+            "time": "2024-03-18T12:38:27+00:00"
         },
         {
             "name": "olcs/olcs-utils",
@@ -11959,7 +11959,10 @@
     "platform": {
         "php": "^7.4",
         "ext-intl": "*",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-curl": "*",
+        "ext-redis": "*",
+        "ext-pdo": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/module/Api/src/Domain/Repository/AbstractReadonlyRepository.php
+++ b/module/Api/src/Domain/Repository/AbstractReadonlyRepository.php
@@ -400,7 +400,7 @@ abstract class AbstractReadonlyRepository implements ReadonlyRepositoryInterface
         $query = $qb->getQuery();
         $query->setHydrationMode($hydrateMode);
 
-        if ($originalQuery instanceof PagedQueryInterface) {
+        if ($this->query instanceof PagedQueryInterface || ($originalQuery instanceof PagedQueryInterface)) {
             $paginator = $this->getPaginator($query);
 
             return $paginator->getIterator($hydrateMode);

--- a/module/Api/src/Domain/Repository/AbstractReadonlyRepository.php
+++ b/module/Api/src/Domain/Repository/AbstractReadonlyRepository.php
@@ -389,17 +389,18 @@ abstract class AbstractReadonlyRepository implements ReadonlyRepositoryInterface
     /**
      * Abstracted paginator logic so it can be re-used with alternative queries
      *
-     * @param QueryBuilder $qb          Doctrine query builder
-     * @param int          $hydrateMode Hydrate mode
+     * @param QueryBuilder $qb              Doctrine query builder
+     * @param int          $hydrateMode     Hydrate mode
+     * @param QueryInterface $originalQuery Original query
      *
      * @return \ArrayIterator|\Traversable
      */
-    public function fetchPaginatedList(QueryBuilder $qb, $hydrateMode = Query::HYDRATE_ARRAY)
+    public function fetchPaginatedList(QueryBuilder $qb, $hydrateMode = Query::HYDRATE_ARRAY, QueryInterface $originalQuery = null)
     {
         $query = $qb->getQuery();
         $query->setHydrationMode($hydrateMode);
 
-        if ($this->query instanceof PagedQueryInterface) {
+        if ($originalQuery instanceof PagedQueryInterface) {
             $paginator = $this->getPaginator($query);
 
             return $paginator->getIterator($hydrateMode);

--- a/module/Api/src/Domain/Repository/Message.php
+++ b/module/Api/src/Domain/Repository/Message.php
@@ -4,6 +4,7 @@ namespace Dvsa\Olcs\Api\Domain\Repository;
 
 use Doctrine\DBAL\ParameterType;
 use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Dvsa\Olcs\Api\Entity\Messaging\MessagingMessage as Entity;
 use Dvsa\Olcs\Transfer\Query\QueryInterface;
@@ -49,6 +50,18 @@ class Message extends AbstractRepository
         $qb
             ->andWhere($qb->expr()->eq($this->alias . '.messagingConversation', ':messagingConversation'))
             ->setParameter('messagingConversation', $conversationId);
+
+        return $qb;
+    }
+
+    public function addReadersToMessages(QueryBuilder $qb): QueryBuilder
+    {
+        $qb->leftJoin($this->alias . '.userMessageReads', 'urm')
+           ->leftJoin('urm.user', 'urmu')
+           ->leftJoin('urmu.contactDetails', 'urmcd')
+           ->leftJoin('urmcd.person', 'urmcdp')
+           ->leftJoin('urmu.roles', 'urmur')
+           ->addSelect('urm, urmcd, urmcdp, urmu, urmur');
 
         return $qb;
     }

--- a/test/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversationTest.php
+++ b/test/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversationTest.php
@@ -3,6 +3,7 @@
 namespace Dvsa\OlcsTest\Api\Domain\QueryHandler\Messaging\Message;
 
 use ArrayIterator;
+use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Dvsa\Olcs\Api\Domain\QueryHandler\Messaging\Message\ByConversation;
 use Dvsa\Olcs\Api\Domain\Repository;
@@ -12,6 +13,7 @@ use Dvsa\Olcs\Api\Entity\Messaging\MessagingConversation;
 use Dvsa\Olcs\Api\Entity\Messaging\MessagingUserMessageRead;
 use Dvsa\Olcs\Api\Entity\Task\Task;
 use Dvsa\Olcs\Api\Entity\User\Permission;
+use Dvsa\Olcs\Api\Entity\User\Role;
 use Dvsa\Olcs\Transfer\Query\Messaging\Messages\ByConversation as Qry;
 use Dvsa\OlcsTest\Api\Domain\QueryHandler\QueryHandlerTestCase;
 use LmcRbacMvc\Service\AuthorizationService;
@@ -37,27 +39,51 @@ class ByConversationTest extends QueryHandlerTestCase
     {
         $query = Qry::create([
             'conversation' => 1,
+            'includeReadRoles' => true,
+            'readRoles' => [Role::ROLE_OPERATOR_USER],
         ]);
 
         $messages = new ArrayIterator(
             [
-                ['id' => 1,'messaging_conversation_id' => '1','messaging_content_id' => '1'],
-                ['id' => 2,'messaging_conversation_id' => '1','messaging_content_id' => '2'],
-                ['id' => 3,'messaging_conversation_id' => '1','messaging_content_id' => '3'],
-                ['id' => 4,'messaging_conversation_id' => '1','messaging_content_id' => '4'],
-                ['id' => 5,'messaging_conversation_id' => '1','messaging_content_id' => '5'],
-                ['id' => 6,'messaging_conversation_id' => '1','messaging_content_id' => '6'],
-                ['id' => 7,'messaging_conversation_id' => '1','messaging_content_id' => '7'],
-                ['id' => 8,'messaging_conversation_id' => '1','messaging_content_id' => '8'],
-            ]
+                ['id' => 1, 'messaging_conversation_id' => '1', 'messaging_content_id' => '1', 'userMessageReads' => [['user' => ['roles' => [['role' => Role::ROLE_OPERATOR_USER]]]]]],
+                ['id' => 2, 'messaging_conversation_id' => '1', 'messaging_content_id' => '2', 'userMessageReads' => [['user' => ['roles' => [['role' => Role::ROLE_OPERATOR_TM]]]]]],
+                ['id' => 3, 'messaging_conversation_id' => '1', 'messaging_content_id' => '3', 'userMessageReads' => [['user' => ['roles' => []]]]],
+                ['id' => 4, 'messaging_conversation_id' => '1', 'messaging_content_id' => '4', 'userMessageReads' => [['user' => ['roles' => []]]]],
+                ['id' => 5, 'messaging_conversation_id' => '1', 'messaging_content_id' => '5', 'userMessageReads' => [['user' => ['roles' => []]]]],
+                ['id' => 6, 'messaging_conversation_id' => '1', 'messaging_content_id' => '6', 'userMessageReads' => [['user' => ['roles' => []]]]],
+                ['id' => 7, 'messaging_conversation_id' => '1', 'messaging_content_id' => '7', 'userMessageReads' => [['user' => ['roles' => []]]]],
+                ['id' => 8, 'messaging_conversation_id' => '1', 'messaging_content_id' => '8', 'userMessageReads' => [['user' => ['roles' => []]]]],
+            ],
         );
         $conversation = new MessagingConversation();
         $mockQb = m::mock(QueryBuilder::class);
-        $this->repoMap[Repository\Message::class]->shouldReceive('getBaseMessageListWithContentQuery')->andReturn($mockQb);
-        $this->repoMap[Repository\Message::class]->shouldReceive('filterByConversationId')->andReturn($mockQb);
-        $this->repoMap[Repository\Message::class]->shouldReceive('fetchPaginatedList')->with($mockQb)->once()->andReturn($messages);
-        $this->repoMap[Repository\Message::class]->shouldReceive('fetchPaginatedCount')->with($mockQb)->once()->andReturn(10);
-        $this->repoMap[Repository\Conversation::class]->shouldReceive('fetchById')->with(1)->once()->andReturn($conversation);
+        $this->repoMap[Repository\Message::class]
+            ->shouldReceive('getBaseMessageListWithContentQuery')
+            ->once()
+            ->andReturn($mockQb);
+        $this->repoMap[Repository\Message::class]
+            ->shouldReceive('filterByConversationId')
+            ->once()
+            ->andReturn($mockQb);
+        $this->repoMap[Repository\Message::class]
+            ->shouldReceive('addReadersToMessages')
+            ->once()
+            ->andReturn($mockQb);
+        $this->repoMap[Repository\Message::class]
+            ->shouldReceive('fetchPaginatedList')
+            ->with($mockQb, Query::HYDRATE_ARRAY, $query)
+            ->once()
+            ->andReturn($messages);
+        $this->repoMap[Repository\Message::class]
+            ->shouldReceive('fetchPaginatedCount')
+            ->with($mockQb)
+            ->once()
+            ->andReturn(10);
+        $this->repoMap[Repository\Conversation::class]
+            ->shouldReceive('fetchById')
+            ->with(1)
+            ->once()
+            ->andReturn($conversation);
 
         foreach ($messages as $message) {
             $this->repoMap[Repository\Message::class]
@@ -93,6 +119,7 @@ class ByConversationTest extends QueryHandlerTestCase
 
         $result = $this->sut->handleQuery($query);
 
+
         $this->assertArrayHasKey('application', $result);
         $this->assertArrayHasKey('licence', $result);
         $this->assertArrayHasKey('result', $result);
@@ -101,5 +128,7 @@ class ByConversationTest extends QueryHandlerTestCase
         $this->assertEquals(10, $result['count']);
         $this->assertEquals(456, $result['application']['id']);
         $this->assertEquals(123, $result['licence']['id']);
+        $this->assertNotEmpty($result['result'][0]['userMessageReads']);
+        $this->assertEmpty($result['result'][1]['userMessageReads']);
     }
 }

--- a/test/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversationTest.php
+++ b/test/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversationTest.php
@@ -118,8 +118,7 @@ class ByConversationTest extends QueryHandlerTestCase
         $this->repoMap[Repository\MessagingUserMessageRead::class]->shouldReceive('save')->times(count($messages));
 
         $result = $this->sut->handleQuery($query);
-
-
+        
         $this->assertArrayHasKey('application', $result);
         $this->assertArrayHasKey('licence', $result);
         $this->assertArrayHasKey('result', $result);

--- a/test/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversationTest.php
+++ b/test/module/Api/src/Domain/QueryHandler/Messaging/Message/ByConversationTest.php
@@ -118,7 +118,7 @@ class ByConversationTest extends QueryHandlerTestCase
         $this->repoMap[Repository\MessagingUserMessageRead::class]->shouldReceive('save')->times(count($messages));
 
         $result = $this->sut->handleQuery($query);
-        
+
         $this->assertArrayHasKey('application', $result);
         $this->assertArrayHasKey('licence', $result);
         $this->assertArrayHasKey('result', $result);


### PR DESCRIPTION
## Description

Add a footer to internal to show the first operator to read the message.

Related issue: [VOL-5082](https://dvsa.atlassian.net/browse/VOL-5082)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
