### PR TITLE
feat: Automatically close tasks when conversation closed

### DIFF
--- a/test/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Close.php
+++ b/test/module/Api/src/Domain/CommandHandler/Messaging/Conversation/Close.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\OlcsTest\Api\Domain\CommandHandler\Messaging\Conversation;
+
+use Dvsa\Olcs\Api\Domain\Command\Email\CreateCorrespondenceRecord;
+use Dvsa\Olcs\Api\Domain\Command\Messaging\Conversation\StoreSnapshot;
+use Dvsa\Olcs\Api\Domain\Command\Result;
+use Dvsa\Olcs\Api\Domain\Command\Task\CreateTask;
+use Dvsa\Olcs\Api\Domain\CommandHandler\Messaging\Conversation\Close as CloseConversationHandler;
+use Dvsa\Olcs\Api\Domain\Exception\Exception;
+use Dvsa\Olcs\Api\Domain\Repository;
+use Dvsa\Olcs\Api\Entity;
+use Dvsa\Olcs\Transfer\Command\Messaging\Conversation\Close as CloseConversationCommand;
+use Dvsa\Olcs\Transfer\Command\Task\CloseTasks;
+use Dvsa\OlcsTest\Api\Domain\CommandHandler\CommandHandlerTestCase;
+use LmcRbacMvc\Service\AuthorizationService;
+use Mockery as m;
+
+class Close extends CommandHandlerTestCase
+{
+    public function setUp(): void
+    {
+        $this->sut = new CloseConversationHandler();
+        $this->mockRepo(Repository\Conversation::class, Repository\Conversation::class);
+
+        $this->mockedSmServices = [
+            AuthorizationService::class => m::mock(AuthorizationService::class),
+        ];
+
+        $defaultMockTask = m::mock(Entity\Task\Task::class)->makePartial()->allows('getId')->getMock();
+        $defaultMockConversation = m::mock(Entity\Messaging\MessagingConversation::class)->makePartial()->allows('getTask')->andReturn($defaultMockTask)->getMock()->allows('getRelatedLicence')->getMock();
+        $this->repoMap[Repository\Conversation::class]->allows('fetchUsingId')->andReturn($defaultMockConversation)->byDefault();
+        $this->repoMap[Repository\Conversation::class]->allows('save')->byDefault();
+
+        parent::setUp();
+
+        $this->commandHandler->allows('handleCommand')->andReturn(new Result())->byDefault();
+    }
+
+    public function testHandleMarksConversationAsClosed()
+    {
+        $command = CloseConversationCommand::create($commandParameters = ['id' => 1]);
+
+        $this->repoMap[Repository\Conversation::class]->expects('save')->with(m::on(function ($conversation) {
+            $this->assertTrue($conversation->getIsClosed());
+            return true;
+        }));
+
+        $this->sut->handleCommand($command);
+    }
+
+    public function testHandleMarksTaskAsClosed()
+    {
+        $command = CloseConversationCommand::create($commandParameters = ['id' => 1]);
+
+        $this->expectedSideEffect(CloseTasks::class, [], new Result(), 1);
+
+        $this->sut->handleCommand($command);
+    }
+
+    public function testHandleGeneratesAndStoresSnapshot()
+    {
+        $command = CloseConversationCommand::create($commandParameters = ['id' => 1]);
+
+        $this->expectedSideEffect(StoreSnapshot::class, [], new Result(), 1);
+
+        $this->sut->handleCommand($command);
+    }
+
+    public function testHandleCreatesCorrespondenceRecord()
+    {
+        $command = CloseConversationCommand::create($commandParameters = ['id' => 1]);
+
+        $this->expectedSideEffect(CreateCorrespondenceRecord::class, [], new Result(), 1);
+
+        $this->sut->handleCommand($command);
+    }
+}


### PR DESCRIPTION
## Description

- Automatically close the conversations corrisponding task when a conversation is closed.
- Some basic refactoring.
- Added missing unit test coverate for Close command.

Related issue: https://dvsa.atlassian.net/browse/VOL-5152

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
