### PR TITLE
feat: change Doctrine cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,6 @@ vendor/bin
 test/coverage-report
 *.sw?
 data/mapping
-data/DoctrineORMModule
-data/cache/*
 data/db/Etl
 data/db/live-like-data.sql
 data/db/test-olcs-refdata.sql

--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -21,9 +21,7 @@ return array(
         'configuration' => array(
             'orm_default' => array(
                 // If running as CLI then use different directory to avoid permissions problems
-                'proxy_dir'         => (PHP_SAPI === 'cli') ?
-                    sys_get_temp_dir() . '/EntityCli/Proxy' :
-                    sys_get_temp_dir() . '/Entity/Proxy',
+                'proxy_dir'         => 'data/cache/DoctrineORMModule',
                 'proxy_namespace'   => 'Dvsa\Olcs\Api\Entity\Proxy',
                 'datetime_functions' => [
                     'date'          => 'Oro\ORM\Query\AST\Functions\SimpleFunction',

--- a/data/cache/DoctrineORMModule/.gitignore
+++ b/data/cache/DoctrineORMModule/.gitignore
@@ -1,3 +1,2 @@
 *
 !.gitignore
-!*/


### PR DESCRIPTION
## Description

Updates the cache directory of Doctrine from `/tmp` to `data/cache/DoctrineORMModule`. This consolidates the directories that are needed by the application to simplify permissions.

Related issue: https://dvsa.atlassian.net/browse/VOL-4679

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
