### PR TITLE
fix: Add ROLE_OPERATOR_ADMIN to messaging filtering roles

### DIFF
--- a/module/Api/src/Domain/QueryHandler/Messaging/Conversations/AbstractConversationQueryHandler.php
+++ b/module/Api/src/Domain/QueryHandler/Messaging/Conversations/AbstractConversationQueryHandler.php
@@ -37,6 +37,7 @@ abstract class AbstractConversationQueryHandler extends AbstractQueryHandler
             ];
         } else {
             return [
+                Role::ROLE_OPERATOR_ADMIN,
                 Role::ROLE_OPERATOR_USER,
                 Role::ROLE_OPERATOR_TM,
             ];

--- a/module/Api/src/Domain/QueryHandler/Messaging/Conversations/AbstractConversationQueryHandler.php
+++ b/module/Api/src/Domain/QueryHandler/Messaging/Conversations/AbstractConversationQueryHandler.php
@@ -39,7 +39,6 @@ abstract class AbstractConversationQueryHandler extends AbstractQueryHandler
             return [
                 Role::ROLE_OPERATOR_ADMIN,
                 Role::ROLE_OPERATOR_USER,
-                Role::ROLE_OPERATOR_TM,
             ];
         }
     }

--- a/test/module/Api/src/Domain/QueryHandler/Messaging/Conversations/ByLicenceTest.php
+++ b/test/module/Api/src/Domain/QueryHandler/Messaging/Conversations/ByLicenceTest.php
@@ -56,7 +56,7 @@ class ByLicenceTest extends QueryHandlerTestCase
         $this->repoMap[Repository\Conversation::class]
             ->shouldReceive('applyOrderForListing')
             ->once()
-            ->with($mockQb, ['operator-admin', 'operator-user', 'operator-tm'])
+            ->with($mockQb, ['operator-admin', 'operator-user'])
             ->andReturn($mockQb);
         $this->repoMap[Repository\Conversation::class]
             ->shouldReceive('filterByStatuses')

--- a/test/module/Api/src/Domain/QueryHandler/Messaging/Conversations/ByLicenceTest.php
+++ b/test/module/Api/src/Domain/QueryHandler/Messaging/Conversations/ByLicenceTest.php
@@ -56,7 +56,7 @@ class ByLicenceTest extends QueryHandlerTestCase
         $this->repoMap[Repository\Conversation::class]
             ->shouldReceive('applyOrderForListing')
             ->once()
-            ->with($mockQb, ['operator-user', 'operator-tm'])
+            ->with($mockQb, ['operator-admin', 'operator-user', 'operator-tm'])
             ->andReturn($mockQb);
         $this->repoMap[Repository\Conversation::class]
             ->shouldReceive('filterByStatuses')

--- a/test/module/Api/src/Domain/QueryHandler/Messaging/Conversations/ByOrganisationTest.php
+++ b/test/module/Api/src/Domain/QueryHandler/Messaging/Conversations/ByOrganisationTest.php
@@ -67,7 +67,7 @@ class ByOrganisationTest extends QueryHandlerTestCase
         $this->repoMap[Repository\Conversation::class]
             ->shouldReceive('applyOrderForListing')
             ->once()
-            ->with($mockQb, ['operator-admin', 'operator-user', 'operator-tm'])
+            ->with($mockQb, ['operator-admin', 'operator-user'])
             ->andReturn($mockQb);
         $this->repoMap[Repository\Conversation::class]
             ->shouldReceive('fetchPaginatedList')

--- a/test/module/Api/src/Domain/QueryHandler/Messaging/Conversations/ByOrganisationTest.php
+++ b/test/module/Api/src/Domain/QueryHandler/Messaging/Conversations/ByOrganisationTest.php
@@ -67,7 +67,7 @@ class ByOrganisationTest extends QueryHandlerTestCase
         $this->repoMap[Repository\Conversation::class]
             ->shouldReceive('applyOrderForListing')
             ->once()
-            ->with($mockQb, ['operator-user', 'operator-tm'])
+            ->with($mockQb, ['operator-admin', 'operator-user', 'operator-tm'])
             ->andReturn($mockQb);
         $this->repoMap[Repository\Conversation::class]
             ->shouldReceive('fetchPaginatedList')


### PR DESCRIPTION
## Description

Include operator admin role in messaging filtering.

Related issue: [VOL-5114](https://dvsa.atlassian.net/browse/VOL-5114)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
