### PR TITLE
fix: Validator for messaging attachments based on correlation ID

### DIFF
--- a/module/Api/config/validation-map/messaging.config.php
+++ b/module/Api/config/validation-map/messaging.config.php
@@ -3,6 +3,7 @@
 use Dvsa\Olcs\Api\Domain\CommandHandler;
 use Dvsa\Olcs\Api\Domain\QueryHandler;
 use Dvsa\Olcs\Api\Domain\Validation\Handlers\Document\CanAccessDocumentsWithIds;
+use Dvsa\Olcs\Api\Domain\Validation\Handlers\Messaging\CanAccessCorrelatedDocuments;
 use Dvsa\Olcs\Api\Domain\Validation\Handlers\Messaging\CanCloseConversationWithId;
 use Dvsa\Olcs\Api\Domain\Validation\Handlers\Messaging\CanCreateConversationForOrganisation;
 use Dvsa\Olcs\Api\Domain\Validation\Handlers\Messaging\CanCreateMessageWithConversation;
@@ -24,7 +25,7 @@ return [
     QueryHandler\Messaging\ApplicationLicenceList\ByCaseToOrganisation::class        => IsInternalUser::class,
     QueryHandler\Messaging\ApplicationLicenceList\ByLicenceToOrganisation::class     => IsInternalUser::class,
     QueryHandler\Messaging\Message\ByConversation::class                             => CanAccessConversationMessagesWithConversationId::class,
-    QueryHandler\Messaging\Documents::class                                          => CanAccessDocumentsWithIds::class,
+    QueryHandler\Messaging\Documents::class                                          => CanAccessCorrelatedDocuments::class,
     CommandHandler\Messaging\Conversation\Close::class                               => CanCloseConversationWithId::class,
     CommandHandler\Messaging\Conversation\Disable::class                             => IsInternalUser::class,
     CommandHandler\Messaging\Conversation\Enable::class                              => IsInternalUser::class,

--- a/module/Api/src/Domain/Validation/Handlers/Messaging/CanAccessCorrelatedDocuments.php
+++ b/module/Api/src/Domain/Validation/Handlers/Messaging/CanAccessCorrelatedDocuments.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\Olcs\Api\Domain\Validation\Handlers\Messaging;
+
+use Dvsa\Olcs\Api\Domain\AuthAwareInterface;
+use Dvsa\Olcs\Api\Domain\AuthAwareTrait;
+use Dvsa\Olcs\Api\Domain\CacheAwareInterface;
+use Dvsa\Olcs\Api\Domain\CacheAwareTrait;
+use Dvsa\Olcs\Api\Domain\Exception\NotFoundException;
+use Dvsa\Olcs\Api\Domain\Repository;
+use Dvsa\Olcs\Api\Domain\RepositoryManagerAwareInterface;
+use Dvsa\Olcs\Api\Domain\RepositoryManagerAwareTrait;
+use Dvsa\Olcs\Api\Domain\Validation\Handlers\AbstractHandler;
+use Dvsa\Olcs\Api\Entity\Doc\Document;
+use Dvsa\Olcs\Transfer\Query\Messaging\Documents;
+use Dvsa\Olcs\Transfer\Service\CacheEncryption;
+
+class CanAccessCorrelatedDocuments extends AbstractHandler implements CacheAwareInterface, RepositoryManagerAwareInterface, AuthAwareInterface
+{
+    use CacheAwareTrait;
+    use RepositoryManagerAwareTrait;
+    use AuthAwareTrait;
+
+    /** @param Documents $dto */
+    public function isValid($dto)
+    {
+        $documentIds = $this->getCache()->getCustomItem(
+            CacheEncryption::GENERIC_STORAGE_IDENTIFIER,
+            $dto->getCorrelationId(),
+        ) ?: [];
+
+        $repo = $this->getRepo(Repository\Document::class);
+
+        foreach ($documentIds as $documentId) {
+            /** @var Document $doc */
+            try {
+                $doc = $repo->fetchById($documentId);
+            } catch (NotFoundException $ex) {
+                continue;
+            }
+            if ($doc && $doc->getCreatedBy()->getId() !== $this->getUser()->getId()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/module/Api/src/Domain/Validation/ValidationHelperTrait.php
+++ b/module/Api/src/Domain/Validation/ValidationHelperTrait.php
@@ -9,7 +9,9 @@
 namespace Dvsa\Olcs\Api\Domain\Validation;
 
 use Dvsa\Olcs\Api\Domain\AuthAwareInterface;
+use Dvsa\Olcs\Api\Domain\CacheAwareInterface;
 use Dvsa\Olcs\Api\Domain\RepositoryManagerAwareInterface;
+use Dvsa\Olcs\Transfer\Service\CacheEncryption;
 use Psr\Container\ContainerInterface;
 use LmcRbacMvc\Service\AuthorizationService;
 use Dvsa\Olcs\Api\Domain\ValidatorManager;
@@ -122,6 +124,10 @@ trait ValidationHelperTrait
     {
         if ($this instanceof AuthAwareInterface) {
             $this->setAuthService($container->get(AuthorizationService::class));
+        }
+
+        if ($this instanceof CacheAwareInterface) {
+            $this->setCache($container->get(CacheEncryption::class));
         }
 
         if ($this instanceof RepositoryManagerAwareInterface) {

--- a/module/Api/src/Domain/Validation/Validators/CanAccessDocument.php
+++ b/module/Api/src/Domain/Validation/Validators/CanAccessDocument.php
@@ -2,12 +2,9 @@
 
 namespace Dvsa\Olcs\Api\Domain\Validation\Validators;
 
-use Dvsa\Olcs\Api\Domain\Exception\NotFoundException;
-use Dvsa\Olcs\Api\Domain\Repository\Document;
 use Dvsa\Olcs\Api\Domain\Repository\TxcInbox as TxcInboxRepo;
 use Dvsa\Olcs\Api\Entity\Bus\LocalAuthority;
 use Dvsa\Olcs\Api\Entity\Ebsr\TxcInbox as TxcInboxEntity;
-use Dvsa\Olcs\Api\Entity\Organisation\Organisation;
 
 /**
  * Can Access a Document
@@ -51,16 +48,6 @@ class CanAccessDocument extends AbstractCanAccessEntity
                     return true;
                 }
             }
-        }
-
-        try {
-            $doc = $this->getRepo(Document::class)->fetchById((int)$entityId);
-        } catch (NotFoundException $ex) {
-            return false;
-        }
-
-        if ($doc->getCreatedBy()->getId() === $this->getUser()->getId()) {
-            return true;
         }
 
         return false;

--- a/module/Api/src/Domain/Validation/Validators/CanAccessDocument.php
+++ b/module/Api/src/Domain/Validation/Validators/CanAccessDocument.php
@@ -2,6 +2,8 @@
 
 namespace Dvsa\Olcs\Api\Domain\Validation\Validators;
 
+use Dvsa\Olcs\Api\Domain\Exception\NotFoundException;
+use Dvsa\Olcs\Api\Domain\Repository\Document;
 use Dvsa\Olcs\Api\Domain\Repository\TxcInbox as TxcInboxRepo;
 use Dvsa\Olcs\Api\Entity\Bus\LocalAuthority;
 use Dvsa\Olcs\Api\Entity\Ebsr\TxcInbox as TxcInboxEntity;
@@ -49,6 +51,16 @@ class CanAccessDocument extends AbstractCanAccessEntity
                     return true;
                 }
             }
+        }
+
+        try {
+            $doc = $this->getRepo(Document::class)->fetchById((int)$entityId);
+        } catch (NotFoundException $ex) {
+            return false;
+        }
+
+        if ($doc->getCreatedBy()->getId() === $this->getUser()->getId()) {
+            return true;
         }
 
         return false;

--- a/module/Api/src/Entity/Doc/Document.php
+++ b/module/Api/src/Entity/Doc/Document.php
@@ -212,6 +212,10 @@ class Document extends AbstractDocument implements OrganisationProviderInterface
             return $this->getMessagingConversation()->getRelatedOrganisation();
         }
 
+        if ($this->getCreatedBy()) {
+            return $this->getCreatedBy()->getRelatedOrganisation();
+        }
+
         return null;
     }
 

--- a/test/module/Api/src/Domain/Validation/ValidationHelperTestCaseTrait.php
+++ b/test/module/Api/src/Domain/Validation/ValidationHelperTestCaseTrait.php
@@ -11,6 +11,7 @@ namespace Dvsa\OlcsTest\Api\Domain\Validation;
 use Dvsa\Olcs\Api\Domain\Repository\RepositoryInterface;
 use Dvsa\Olcs\Api\Domain\Validation\Validators\ValidatorInterface;
 use Dvsa\Olcs\Api\Entity\User\User;
+use Dvsa\Olcs\Transfer\Service\CacheEncryption;
 use Mockery as m;
 use Dvsa\Olcs\Api\Domain\RepositoryServiceManager;
 use Laminas\ServiceManager\ServiceManager;
@@ -44,12 +45,14 @@ trait ValidationHelperTestCaseTrait
     {
         $this->repoManager = m::mock(RepositoryServiceManager::class);
         $this->auth = m::mock(AuthorizationService::class);
+        $this->cache = m::mock(CacheEncryption::class);
         $this->validatorManager = m::mock(ValidatorManager::class)->makePartial();
 
         $sm = m::mock(ServiceManager::class)->makePartial();
         $sm->setService('RepositoryServiceManager', $this->repoManager);
         $sm->setService(AuthorizationService::class, $this->auth);
         $sm->setService('DomainValidatorManager', $this->validatorManager);
+        $sm->setService(CacheEncryption::class, $this->cache);
         $sm->setService('config', ['config']);
 
         $this->sut->__invoke($sm, null);

--- a/test/module/Api/src/Domain/Validation/Validators/CanAccessCorrelatedDocumentsTest.php
+++ b/test/module/Api/src/Domain/Validation/Validators/CanAccessCorrelatedDocumentsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\OlcsTest\Api\Domain\Validation\Validators;
+
+use Dvsa\Olcs\Api\Domain\Repository;
+use Dvsa\Olcs\Api\Domain\Validation\Handlers\Messaging\CanAccessCorrelatedDocuments;
+use Dvsa\Olcs\Api\Entity;
+use Dvsa\Olcs\Transfer\Query\Messaging\Documents;
+use Dvsa\Olcs\Transfer\Service\CacheEncryption;
+use Mockery as m;
+
+/**
+ * Can Access Document Test
+ */
+class CanAccessCorrelatedDocumentsTest extends AbstractValidatorsTestCase
+{
+    /**
+     * @var CanAccessCorrelatedDocuments|m\MockInterface
+     */
+    protected $sut;
+
+    public function setUp(): void
+    {
+        $this->sut = m::mock(CanAccessCorrelatedDocuments::class)
+                      ->makePartial()
+                      ->shouldAllowMockingProtectedMethods();
+
+        parent::setUp();
+    }
+
+    public function testIsValidTrue()
+    {
+        $doc = m::mock(Entity\Doc\Document::class);
+        $doc->shouldReceive('getCreatedBy->getId')
+            ->once()
+            ->andReturn(1);
+
+        $this->auth->shouldReceive('getIdentity->getUser->getId')
+                   ->once()
+                   ->andReturn(1);
+
+        $docRepo = $this->mockRepo(Repository\Document::class);
+        $docRepo->shouldReceive('fetchById')
+                ->once()
+                ->with(1)
+                ->andReturn($doc);
+
+        $this->cache->shouldReceive('getCustomItem')
+                    ->once()
+                    ->with(CacheEncryption::GENERIC_STORAGE_IDENTIFIER, '1234567890')
+                    ->andReturn([1]);
+
+        $query = Documents::create(['correlationId' => '1234567890']);
+        $this->assertTrue($this->sut->isValid($query));
+    }
+
+    public function testIsValidFalse()
+    {
+        $doc = m::mock(Entity\Doc\Document::class);
+        $doc->shouldReceive('getCreatedBy->getId')
+            ->once()
+            ->andReturn(1);
+
+        $this->auth->shouldReceive('getIdentity->getUser->getId')
+                   ->once()
+                   ->andReturn(2);
+
+        $docRepo = $this->mockRepo(Repository\Document::class);
+        $docRepo->shouldReceive('fetchById')
+                ->once()
+                ->with(1)
+                ->andReturn($doc);
+
+        $this->cache->shouldReceive('getCustomItem')
+                    ->once()
+                    ->with(CacheEncryption::GENERIC_STORAGE_IDENTIFIER, '1234567890')
+                    ->andReturn([1]);
+
+        $query = Documents::create(['correlationId' => '1234567890']);
+        $this->assertFalse($this->sut->isValid($query));
+    }
+}

--- a/test/module/Api/src/Domain/Validation/Validators/CanAccessDocumentTest.php
+++ b/test/module/Api/src/Domain/Validation/Validators/CanAccessDocumentTest.php
@@ -2,10 +2,8 @@
 
 namespace Dvsa\OlcsTest\Api\Domain\Validation\Validators;
 
-use Dvsa\Olcs\Api\Domain\Repository\Document;
 use Dvsa\Olcs\Api\Domain\Validation\Validators\CanAccessDocument;
 use Dvsa\Olcs\Api\Entity\Bus\LocalAuthority;
-use Dvsa\Olcs\Api\Entity\Ebsr\TxcInbox;
 use Mockery as m;
 
 /**

--- a/test/module/Api/src/Domain/Validation/Validators/CanAccessDocumentTest.php
+++ b/test/module/Api/src/Domain/Validation/Validators/CanAccessDocumentTest.php
@@ -2,8 +2,7 @@
 
 namespace Dvsa\OlcsTest\Api\Domain\Validation\Validators;
 
-use Dvsa\Olcs\Api\Domain\Repository;
-use Dvsa\Olcs\Api\Entity;
+use Dvsa\Olcs\Api\Domain\Repository\Document;
 use Dvsa\Olcs\Api\Domain\Validation\Validators\CanAccessDocument;
 use Dvsa\Olcs\Api\Entity\Bus\LocalAuthority;
 use Dvsa\Olcs\Api\Entity\Ebsr\TxcInbox;
@@ -53,21 +52,6 @@ class CanAccessDocumentTest extends AbstractValidatorsTestCase
         $txcInboxRepo->shouldReceive('fetchLinkedToDocument')
             ->andReturn($linkedTxcInboxEntities);
 
-        $doc = m::mock(Entity\Doc\Document::class);
-        $doc->shouldReceive('getCreatedBy->getId')
-            ->once()
-            ->andReturn(1);
-
-        $this->auth->shouldReceive('getIdentity->getUser->getId')
-                   ->once()
-                   ->andReturn(2);
-
-        $docRepo = $this->mockRepo(Repository\Document::class);
-        $docRepo->shouldReceive('fetchById')
-                ->once()
-                ->with(47)
-                ->andReturn($doc);
-
         $this->assertFalse($this->sut->isValid($txcInboxId));
     }
 
@@ -102,21 +86,6 @@ class CanAccessDocumentTest extends AbstractValidatorsTestCase
         $txcInboxRepo = $this->mockRepo('TxcInbox');
         $txcInboxRepo->shouldReceive('fetchLinkedToDocument')
             ->andReturn($linkedTxcInboxEntities);
-
-        $doc = m::mock(Entity\Doc\Document::class);
-        $doc->shouldReceive('getCreatedBy->getId')
-            ->once()
-            ->andReturn(1);
-
-        $this->auth->shouldReceive('getIdentity->getUser->getId')
-                   ->once()
-                   ->andReturn(2);
-
-        $docRepo = $this->mockRepo(Repository\Document::class);
-        $docRepo->shouldReceive('fetchById')
-                ->once()
-                ->with(47)
-                ->andReturn($doc);
 
         $this->assertFalse($this->sut->isValid($txcInboxId));
     }

--- a/test/module/Api/src/Domain/Validation/Validators/CanAccessDocumentTest.php
+++ b/test/module/Api/src/Domain/Validation/Validators/CanAccessDocumentTest.php
@@ -2,6 +2,8 @@
 
 namespace Dvsa\OlcsTest\Api\Domain\Validation\Validators;
 
+use Dvsa\Olcs\Api\Domain\Repository;
+use Dvsa\Olcs\Api\Entity;
 use Dvsa\Olcs\Api\Domain\Validation\Validators\CanAccessDocument;
 use Dvsa\Olcs\Api\Entity\Bus\LocalAuthority;
 use Dvsa\Olcs\Api\Entity\Ebsr\TxcInbox;
@@ -51,6 +53,21 @@ class CanAccessDocumentTest extends AbstractValidatorsTestCase
         $txcInboxRepo->shouldReceive('fetchLinkedToDocument')
             ->andReturn($linkedTxcInboxEntities);
 
+        $doc = m::mock(Entity\Doc\Document::class);
+        $doc->shouldReceive('getCreatedBy->getId')
+            ->once()
+            ->andReturn(1);
+
+        $this->auth->shouldReceive('getIdentity->getUser->getId')
+                   ->once()
+                   ->andReturn(2);
+
+        $docRepo = $this->mockRepo(Repository\Document::class);
+        $docRepo->shouldReceive('fetchById')
+                ->once()
+                ->with(47)
+                ->andReturn($doc);
+
         $this->assertFalse($this->sut->isValid($txcInboxId));
     }
 
@@ -85,6 +102,21 @@ class CanAccessDocumentTest extends AbstractValidatorsTestCase
         $txcInboxRepo = $this->mockRepo('TxcInbox');
         $txcInboxRepo->shouldReceive('fetchLinkedToDocument')
             ->andReturn($linkedTxcInboxEntities);
+
+        $doc = m::mock(Entity\Doc\Document::class);
+        $doc->shouldReceive('getCreatedBy->getId')
+            ->once()
+            ->andReturn(1);
+
+        $this->auth->shouldReceive('getIdentity->getUser->getId')
+                   ->once()
+                   ->andReturn(2);
+
+        $docRepo = $this->mockRepo(Repository\Document::class);
+        $docRepo->shouldReceive('fetchById')
+                ->once()
+                ->with(47)
+                ->andReturn($doc);
 
         $this->assertFalse($this->sut->isValid($txcInboxId));
     }


### PR DESCRIPTION
## Description

When creating a conversation, it was failing as permissions were trying to check document ID’s that didn’t exist. 

Related issue: [VOL-5175](https://dvsa.atlassian.net/browse/VOL-5175)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
