### PR TITLE
fix: support string document ids

### DIFF
--- a/module/Api/src/Domain/Repository/TxcInbox.php
+++ b/module/Api/src/Domain/Repository/TxcInbox.php
@@ -169,7 +169,7 @@ class TxcInbox extends AbstractRepository
     /**
      * Get a list of TxcInbox entities that are linked to a document
      *
-     * @param int $documentId Document ID
+     * @param mixed $documentId Document ID
      *
      * @return array
      */

--- a/module/Api/src/Domain/Validation/Validators/CanAccessDocument.php
+++ b/module/Api/src/Domain/Validation/Validators/CanAccessDocument.php
@@ -33,7 +33,7 @@ class CanAccessDocument extends AbstractCanAccessEntity
         return parent::isValid($entityId);
     }
 
-    private function canLocalAuthorityAccessDocument(int $documentId): bool
+    private function canLocalAuthorityAccessDocument(string $documentId): bool
     {
         $txcInboxRepo = $this->getRepo(Repository\TxcInbox::class);
         $txcEntities = $txcInboxRepo->fetchLinkedToDocument($documentId);
@@ -58,14 +58,14 @@ class CanAccessDocument extends AbstractCanAccessEntity
     /**
      * @throws NotFoundException
      */
-    private function canExternalUserAccessDocument(int $documentId): bool
+    private function canExternalUserAccessDocument(string $documentId): bool
     {
         return $this->checkDocumentWasExternallyUploaded($documentId)
             || $this->checkDocumentInCorrespondence($documentId)
             || $this->checkIsTxcDocument($documentId);
     }
 
-    private function checkDocumentInCorrespondence(int $documentId): bool
+    private function checkDocumentInCorrespondence(string $documentId): bool
     {
         $currentUserOrganisationId = $this->getCurrentOrganisation() ? $this->getCurrentOrganisation()->getId() : null;
         if ($currentUserOrganisationId === null) {
@@ -87,13 +87,13 @@ class CanAccessDocument extends AbstractCanAccessEntity
     /**
      * @throws NotFoundException
      */
-    private function checkDocumentWasExternallyUploaded(int $documentId): bool
+    private function checkDocumentWasExternallyUploaded(string $documentId): bool
     {
         $document = $this->getRepo(Repository\Document::class)->fetchById($documentId);
         return $document->getIsExternal();
     }
 
-    private function checkIsTxcDocument(int $documentId): bool
+    private function checkIsTxcDocument(string $documentId): bool
     {
         $txcInboxRepo = $this->getRepo(Repository\TxcInbox::class);
         $txcEntities = $txcInboxRepo->fetchLinkedToDocument($documentId);
@@ -104,7 +104,7 @@ class CanAccessDocument extends AbstractCanAccessEntity
     /**
      * @throws NotFoundException
      */
-    private function canTransportManagerAccessDocument(int $documentId): bool
+    private function canTransportManagerAccessDocument(string $documentId): bool
     {
         $document = $this->getRepo(Repository\Document::class)->fetchById($documentId);
         return $document->getCreatedBy()->getId() === $this->getCurrentUser()->getId();

--- a/test/module/Api/src/Domain/Validation/Validators/CanAccessDocumentTest.php
+++ b/test/module/Api/src/Domain/Validation/Validators/CanAccessDocumentTest.php
@@ -27,7 +27,7 @@ class CanAccessDocumentTest extends AbstractValidatorsTestCase
     private const IS_LOCAL_AUTHORITY_USER = 3;
     private const IS_LOCAL_AUTHORITY_ADMIN = 4;
     private const IS_TRANSPORT_MANAGER_USER = 5;
-    private const DOCUMENT_ID = 123;
+    private const DOCUMENT_ID = "123";
 
     public function setUp(): void
     {


### PR DESCRIPTION
## Description

Fix type error issue with document id being a string. Updates the unit test to reflect the true type.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
