### PR TITLE
fix: Update use last login using DQL to prevent optimistic lock

### DIFF
--- a/module/Api/src/Domain/CommandHandler/Auth/Login.php
+++ b/module/Api/src/Domain/CommandHandler/Auth/Login.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Dvsa\Olcs\Api\Domain\CommandHandler\Auth;
 
+use DateTime;
 use Dvsa\Olcs\Api\Domain\Command\Result;
 use Dvsa\Olcs\Api\Domain\CommandHandler\AbstractCommandHandler;
 use Dvsa\Olcs\Api\Domain\CommandHandler\Auth\Exception\UserHasNoOrganisationException;
@@ -126,17 +127,10 @@ class Login extends AbstractCommandHandler
         return $this->result;
     }
 
-    /**
-     * Updates the last_login_at for a given user to NOW().
-     *
-     * @param User $user
-     * @return User
-     * @throws RuntimeException
-     */
     protected function updateUserLastLoginAt(User $user): User
     {
-        $user->setLastLoginAt(new \DateTime());
-        $this->getRepo()->save($user);
+        $this->getRepo()->updateLastLogin($user, new DateTime(), $user);
+
         return $user;
     }
 

--- a/module/Api/src/Domain/Repository/User.php
+++ b/module/Api/src/Domain/Repository/User.php
@@ -413,28 +413,23 @@ class User extends AbstractRepository
         return $qb->getQuery()->iterate();
     }
 
-    /**
-     * @param Entity $user
-     * @param DateTime $lastLoginAt
-     * @param Entity $lastModifiedBy
-     * @return mixed
-     * @throws \Exception
-     */
-    public function updateLastLogin(Entity $user, DateTime $lastLoginAt, Entity $lastModifiedBy)
+    public function updateLastLogin(Entity $user, DateTime $lastLoginAt, Entity $lastModifiedBy): void
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
 
-        $qb
-            ->update(Entity::class, 'u')
-            ->set('u.lastLoginAt', ':lastLoginAt')
-            ->set('u.lastModifiedOn', ':lastModifiedOn')
-            ->set('u.lastModifiedBy', ':lastModifiedBy')
-            ->andWhere($qb->expr()->eq('u.id', ':id'))
-            ->setParameter('lastLoginAt', $lastLoginAt)
-            ->setParameter('id', $user->getId())
-            ->setParameter('lastModifiedBy', $lastModifiedBy->getId())
-            ->setParameter('lastModifiedOn', new DateTime());
+        $qb->update(Entity::class, 'u')
+           ->set('u.lastLoginAt', ':lastLoginAt')
+           ->set('u.lastModifiedOn', ':lastModifiedOn')
+           ->set('u.lastModifiedBy', ':lastModifiedBy')
+           ->set('u.version', 'u.version + 1')
+           ->where('u.id = :id')
+           ->setParameter('id', $user->getId())
+           ->setParameter('lastLoginAt', $lastLoginAt)
+           ->setParameter('lastModifiedBy', $lastModifiedBy->getId())
+           ->setParameter('lastModifiedOn', new DateTime());
 
-        return $qb->getQuery()->execute();
+        $qb->getQuery()->execute();
+
+        $this->refresh($user);
     }
 }


### PR DESCRIPTION
## Description

Directly update user last login via DQL to avoid optimistic lock.

Related issue: [VOL-5251](https://dvsa.atlassian.net/browse/VOL-5251)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
