### PR TITLE
fix: Don't count vehicles on cancelled applications against validation check

### DIFF
--- a/module/Api/src/Entity/Licence/Licence.php
+++ b/module/Api/src/Entity/Licence/Licence.php
@@ -26,6 +26,7 @@ use Dvsa\Olcs\Api\Entity\Publication\Publication as PublicationEntity;
 use Dvsa\Olcs\Api\Entity\Publication\PublicationLink as PublicationLinkEntity;
 use Dvsa\Olcs\Api\Entity\System\RefData;
 use Dvsa\Olcs\Api\Entity\TrafficArea\TrafficArea;
+use Dvsa\Olcs\Api\Entity\Vehicle\Vehicle;
 use Dvsa\Olcs\Api\Service\Document\ContextProviderInterface;
 use Dvsa\Olcs\Api\Entity\Traits\TotAuthVehiclesTrait;
 
@@ -442,7 +443,14 @@ class Licence extends AbstractLicence implements ContextProviderInterface, Organ
             $criteria->andWhere($criteria->expr()->neq('specifiedDate', null));
         }
 
-        return $this->getLicenceVehicles()->matching($criteria);
+        /** @var LicenceVehicle[] $vehicles */
+        $vehicles = $this->getLicenceVehicles()->matching($criteria)->toArray();
+        $vehicles = array_filter(
+            $vehicles,
+            fn($vehicle) => $vehicle->getApplication() === null || $vehicle->getApplication()->getStatus()->getId() !== Application::APPLICATION_STATUS_CANCELLED,
+        );
+
+        return new ArrayCollection($vehicles);
     }
 
     /**

--- a/test/module/Api/src/Entity/Application/ApplicationEntityTest.php
+++ b/test/module/Api/src/Entity/Application/ApplicationEntityTest.php
@@ -14,6 +14,7 @@ use Dvsa\Olcs\Api\Entity\Application\ApplicationCompletion;
 use Dvsa\Olcs\Api\Entity\Application\ApplicationOperatingCentre;
 use Dvsa\Olcs\Api\Entity\Application\S4;
 use Dvsa\Olcs\Api\Entity\Licence\Licence;
+use Dvsa\Olcs\Api\Entity\Licence\LicenceVehicle;
 use Dvsa\Olcs\Api\Entity\OperatingCentre\OperatingCentre;
 use Dvsa\Olcs\Api\Entity\Organisation\Organisation;
 use Dvsa\Olcs\Api\Entity\System\RefData;
@@ -1168,8 +1169,14 @@ class ApplicationEntityTest extends EntityTester
             ->with(m::type(Criteria::class))
             ->andReturn($activeCollection);
 
-        $activeCollection->shouldReceive('count')
-            ->andReturn(6);
+        $lv = m::mock(LicenceVehicle::class);
+        $lv->shouldReceive('getApplication')
+           ->times(6)
+           ->andReturn(null);
+
+        $activeCollection->shouldReceive('toArray')
+                         ->once()
+                         ->andReturn([$lv, $lv, $lv, $lv, $lv, $lv]);
 
         $licence = m::mock(Licence::class)->makePartial();
         $licence->setLicenceVehicles($lvCollection);

--- a/test/module/Api/src/Entity/Licence/LicenceEntityTest.php
+++ b/test/module/Api/src/Entity/Licence/LicenceEntityTest.php
@@ -20,6 +20,7 @@ use Dvsa\Olcs\Api\Entity\Licence\Licence as Entity;
 use Dvsa\Olcs\Api\Entity\Licence\Licence;
 use Dvsa\Olcs\Api\Entity\Licence\LicenceOperatingCentre;
 use Dvsa\Olcs\Api\Entity\Licence\LicenceStatusRule;
+use Dvsa\Olcs\Api\Entity\Licence\LicenceVehicle;
 use Dvsa\Olcs\Api\Entity\Organisation\Organisation as OrganisationEntity;
 use Dvsa\Olcs\Api\Entity\Organisation\TradingName as TradingNameEntity;
 use Dvsa\Olcs\Api\Entity\Permits\IrhpApplication;
@@ -132,15 +133,21 @@ class LicenceEntityTest extends EntityTester
             ->with(m::type(Criteria::class))
             ->andReturn($activeCollection);
 
-        $activeCollection->shouldReceive('count')
-            ->andReturn(6);
+        $lv = m::mock(LicenceVehicle::class);
+        $lv->shouldReceive('getApplication')
+            ->times(4)
+            ->andReturn(null);
+
+        $activeCollection->shouldReceive('toArray')
+            ->once()
+            ->andReturn([$lv, $lv, $lv, $lv]);
 
         $licence = $this->instantiate(Entity::class);
 
         $licence->setTotAuthVehicles(10);
         $licence->setLicenceVehicles($lvCollection);
 
-        $this->assertEquals(4, $licence->getRemainingSpaces());
+        $this->assertEquals(6, $licence->getRemainingSpaces());
     }
 
     public function testGetActiveVehiclesCount()
@@ -153,13 +160,19 @@ class LicenceEntityTest extends EntityTester
             ->with(m::type(Criteria::class))
             ->andReturn($activeCollection);
 
-        $activeCollection->shouldReceive('count')
-            ->andReturn(6);
+        $lv = m::mock(LicenceVehicle::class);
+        $lv->shouldReceive('getApplication')
+            ->once()
+            ->andReturnNull();
+
+        $activeCollection->shouldReceive('toArray')
+                         ->once()
+                         ->andReturn([$lv]);
 
         $licence = $this->instantiate(Entity::class);
         $licence->setLicenceVehicles($lvCollection);
 
-        $this->assertEquals(6, $licence->getActiveVehiclesCount());
+        $this->assertEquals(1, $licence->getActiveVehiclesCount());
     }
 
     public function testGetActiveVehicles()
@@ -172,10 +185,14 @@ class LicenceEntityTest extends EntityTester
             ->with(m::type(Criteria::class))
             ->andReturn($activeCollection);
 
+        $activeCollection->shouldReceive('toArray')
+                         ->once()
+                         ->andReturn([]);
+
         $licence = $this->instantiate(Entity::class);
         $licence->setLicenceVehicles($lvCollection);
 
-        $this->assertSame($activeCollection, $licence->getActiveVehicles());
+        $this->assertInstanceOf(ArrayCollection::class, $licence->getActiveVehicles());
     }
 
     public function testGetOtherActiveLicences()


### PR DESCRIPTION
## Description

Don't count vehicles on cancelled applications against validation check

Related issue: [VOL-3941](https://dvsa.atlassian.net/browse/VOL-3941)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
