### PR TITLE
feat: VOL-5111 add logging of company insolvency check

### DIFF
--- a/test/module/Api/src/Domain/CommandHandler/CompaniesHouse/CompareTest.php
+++ b/test/module/Api/src/Domain/CommandHandler/CompaniesHouse/CompareTest.php
@@ -227,9 +227,6 @@ class CompareTest extends AbstractCommandHandlerTestCase
         $expectedAlertData,
         $expectedSaveData = []
     ) {
-        // $alertSaveResult = ['id' => 123];
-        // $companySaveResult = ['id' => 99];
-
         // expectations
         $this->mockApi
             ->shouldReceive('getCompanyProfile')


### PR DESCRIPTION
## Description

Occasional problems are occurring when processing insolvent companies. This logging will allow us to see what's going on and correct the problem.

Related issue: [VOL-5111](https://dvsa.atlassian.net/browse/VOL-5111)
