### PR TITLE
fix: remove transport manager address optimistic lock

### DIFF
--- a/module/Api/src/Domain/CommandHandler/Traits/DeleteContactDetailsAndAddressTrait.php
+++ b/module/Api/src/Domain/CommandHandler/Traits/DeleteContactDetailsAndAddressTrait.php
@@ -29,7 +29,9 @@ trait DeleteContactDetailsAndAddressTrait
         $this->injectRepos();
         if ($contactDetails->getAddress() !== null) {
             $addressRepo = $this->getRepo('Address');
-            $addressRepo->delete($contactDetails->getAddress());
+            $address = $contactDetails->getAddress();
+            $addressRepo->refresh($address);
+            $addressRepo->delete($address);
         }
         $this->getRepo('ContactDetails')->delete($contactDetails);
     }

--- a/test/module/Api/src/Domain/CommandHandler/Licence/SaveAddressesTest.php
+++ b/test/module/Api/src/Domain/CommandHandler/Licence/SaveAddressesTest.php
@@ -650,7 +650,12 @@ class SaveAddressesTest extends AbstractCommandHandlerTestCase
             )
             ->getMock();
 
-        $this->repoMap['Address']->shouldReceive('delete')->with($transportConsultantAddress);
+        $this->repoMap['Address']->shouldReceive('delete')
+                                 ->once()
+                                 ->with($transportConsultantAddress);
+        $this->repoMap['Address']->shouldReceive('refresh')
+                                 ->once()
+                                 ->with($transportConsultantAddress);
         $result = $this->sut->handleCommand($command);
 
         $expected = [

--- a/test/module/Api/src/Domain/CommandHandler/Traits/DeleteContactDetailsAndAddressTraitTest.php
+++ b/test/module/Api/src/Domain/CommandHandler/Traits/DeleteContactDetailsAndAddressTraitTest.php
@@ -61,7 +61,12 @@ class DeleteContactDetailsAndAddressTraitTest extends AbstractCommandHandlerTest
     public function testMaybeDeleteContactDetailsAndAddress()
     {
         $address = m::mock(AddressEntity::class);
-        $this->repoMap['Address']->shouldReceive('delete')->with($address);
+        $this->repoMap['Address']->shouldReceive('delete')
+                                 ->once()
+                                 ->with($address);
+        $this->repoMap['Address']->shouldReceive('refresh')
+                                 ->once()
+                                 ->with($address);
         $contactDetails = m::mock(ContactDetailsEntity::class);
         $contactDetails->shouldReceive('getAddress')->andReturn($address);
         $this->repoMap['ContactDetails']->shouldReceive('delete')->with($contactDetails);

--- a/test/module/Api/src/Domain/CommandHandler/Workshop/DeleteWorkshopTest.php
+++ b/test/module/Api/src/Domain/CommandHandler/Workshop/DeleteWorkshopTest.php
@@ -58,7 +58,12 @@ class DeleteWorkshopTest extends AbstractCommandHandlerTestCase
         $workshopEntity1->shouldReceive('getContactDetails')->andReturn($contactDetails1);
         $workshopEntity2 = m::mock(WorkshopEntity::class);
         $workshopEntity2->shouldReceive('getContactDetails')->andReturn(null);
-        $this->repoMap['Address']->shouldReceive('delete')->with($address1);
+        $this->repoMap['Address']->shouldReceive('delete')
+                                 ->once()
+                                 ->with($address1);
+        $this->repoMap['Address']->shouldReceive('refresh')
+                                 ->once()
+                                 ->with($address1);
         $this->repoMap['ContactDetails']->shouldReceive('delete')->with($contactDetails1);
 
         $this->repoMap['Workshop']->shouldReceive('fetchById')


### PR DESCRIPTION
## Description

Refresh address before delete as it may have changed further up the stack.

Related issue: [VOL-3410](https://dvsa.atlassian.net/browse/VOL-3410)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
