### PR TITLE
fix: Allow special restricted licence surrender

### DIFF
--- a/module/Api/src/Domain/CommandHandler/Surrender/Approve.php
+++ b/module/Api/src/Domain/CommandHandler/Surrender/Approve.php
@@ -122,7 +122,8 @@ class Approve extends AbstractSurrenderCommandHandler
         $validTypes = [
             Licence::LICENCE_TYPE_STANDARD_NATIONAL,
             Licence::LICENCE_TYPE_STANDARD_INTERNATIONAL,
-            Licence::LICENCE_TYPE_RESTRICTED
+            Licence::LICENCE_TYPE_RESTRICTED,
+            Licence::LICENCE_TYPE_SPECIAL_RESTRICTED,
         ];
 
         return in_array($licType, $validTypes);


### PR DESCRIPTION
## Description

There is a bug in VOL which is currently preventing caseworkers surrendering PSV special restricted licences via the internal caseworker system. This is present in both production and PP upon test. 

Related issue: [VOL-3456](https://dvsa.atlassian.net/browse/VOL-3456)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
