### PR TITLE
fix: WebDav client ignoring auth settings due to capitalisation

### DIFF
--- a/module/DocumentShare/src/Service/ClientFactory.php
+++ b/module/DocumentShare/src/Service/ClientFactory.php
@@ -148,7 +148,7 @@ class ClientFactory implements FactoryInterface
             $sabreClient = new SabreClient(
                 [
                     'baseUri' => $clientOptions['webdav_baseuri'],
-                    'username' => $clientOptions['username'],
+                    'userName' => $clientOptions['username'],
                     'password' => $clientOptions['password']
                 ]
             );


### PR DESCRIPTION
## Description

Auth ignored due to case being wrong.

Related issue: [VOL-4171](https://dvsa.atlassian.net/browse/VOL-4171)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
