### PR TITLE
fix: Remove association between application and operator on application/variation reset

### DIFF
--- a/module/Api/src/Domain/CommandHandler/Application/ResetApplication.php
+++ b/module/Api/src/Domain/CommandHandler/Application/ResetApplication.php
@@ -1,21 +1,17 @@
-<?php
-
-/**
- * Reset Application
- *
- * @author Rob Caiger <rob@clocal.co.uk>
- */
+<?php declare(strict_types=1);
 
 namespace Dvsa\Olcs\Api\Domain\CommandHandler\Application;
 
-use Doctrine\ORM\Query;
 use Dvsa\Olcs\Api\Domain\Command\Application\ResetApplication as Cmd;
 use Dvsa\Olcs\Api\Domain\Command\Result;
 use Dvsa\Olcs\Api\Domain\CommandHandler\AbstractCommandHandler;
 use Dvsa\Olcs\Api\Domain\CommandHandler\Traits\ApplicationResetTrait;
 use Dvsa\Olcs\Api\Domain\CommandHandler\TransactionedInterface;
 use Dvsa\Olcs\Api\Domain\Exception;
-use Dvsa\Olcs\Api\Domain\Repository\Licence as LicenceRepo;
+use Dvsa\Olcs\Api\Domain\Exception\RequiresConfirmationException;
+use Dvsa\Olcs\Api\Domain\Exception\RuntimeException;
+use Dvsa\Olcs\Api\Domain\Exception\ValidationException;
+use Dvsa\Olcs\Api\Domain\Repository;
 use Dvsa\Olcs\Api\Entity\Application\Application;
 use Dvsa\Olcs\Api\Entity\Organisation\Organisation;
 use Dvsa\Olcs\Api\Entity\System\RefData;
@@ -23,28 +19,25 @@ use Dvsa\Olcs\Transfer\Command\Application\CreateApplication as CreateApplicatio
 use Dvsa\Olcs\Transfer\Command\CommandInterface;
 use Psr\Container\ContainerInterface;
 
-/**
- * Reset Application
- *
- * @author Rob Caiger <rob@clocal.co.uk>
- */
 final class ResetApplication extends AbstractCommandHandler implements TransactionedInterface
 {
     use ApplicationResetTrait;
 
+    private Repository\Application $applicationRepo;
+    private Repository\Licence $licenceRepo;
+    private Repository\ApplicationOperatingCentre $applicationOperatingCentreRepo;
+
     /**
-     * @var LicenceRepo
+     * @throws RequiresConfirmationException
+     * @throws RuntimeException
+     * @throws ValidationException
      */
-    private $licenceRepo;
-
-    protected $repoServiceName = 'Application';
-
-    public function handleCommand(CommandInterface $command)
+    public function handleCommand(Cmd|CommandInterface $command): Result
     {
         $result = new Result();
 
         /** @var Application $application */
-        $application = $this->getRepo()->fetchUsingId($command, Query::HYDRATE_OBJECT);
+        $application = $this->applicationRepo->fetchUsingId($command);
 
         $this->validate($command, $application);
 
@@ -62,7 +55,10 @@ final class ResetApplication extends AbstractCommandHandler implements Transacti
         $this->licenceRepo->delete($licence);
         $result->addMessage('Licence removed');
 
-        $this->getRepo()->delete($application);
+        $aocCount = $this->removeAssociationOfApplicationAndOperatingCentres($application);
+        $result->addMessage($aocCount . ' application operating centres associations removed');
+
+        $this->applicationRepo->delete($application);
         $result->addMessage('Application removed');
 
         $result->merge(
@@ -88,33 +84,42 @@ final class ResetApplication extends AbstractCommandHandler implements Transacti
         );
     }
 
-    private function validate(Cmd $command, Application $application)
+    /**
+     * @throws RequiresConfirmationException
+     * @throws ValidationException
+     */
+    private function validate(Cmd $command, Application $application): void
     {
-        if ($command->getConfirm() === false) {
-            // Before we tell the UI we need confirmation, we better validate the values
-            $application->validateTol(
-                $command->getNiFlag(),
-                $this->getRepo()->getRefdataReference($command->getOperatorType()),
-                $this->getRepo()->getRefdataReference($command->getLicenceType()),
-                $this->getRepo()->getRefDataReference($command->getVehicleType()),
-                $command->getLgvDeclarationConfirmation()
-            );
-
-            // Tell the UI we need confirmation
-            throw new Exception\RequiresConfirmationException(
-                'Updating these elements requires confirmation',
-                Application::ERROR_REQUIRES_CONFIRMATION
-            );
+        if ($command->getConfirm() !== false) {
+            return;
         }
 
-        return true;
+        // Before we tell the UI we need confirmation, we better validate the values
+        $application->validateTol(
+            $command->getNiFlag(),
+            $this->applicationRepo->getRefdataReference($command->getOperatorType()),
+            $this->applicationRepo->getRefdataReference($command->getLicenceType()),
+            $this->applicationRepo->getRefDataReference($command->getVehicleType()),
+            $command->getLgvDeclarationConfirmation()
+        );
+
+        // Tell the UI we need confirmation
+        throw new Exception\RequiresConfirmationException(
+            'Updating these elements requires confirmation',
+            Application::ERROR_REQUIRES_CONFIRMATION
+        );
     }
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ResetApplication
     {
         $fullContainer = $container;
 
+        $this->applicationRepo = $container->get('RepositoryServiceManager')
+            ->get('Application');
         $this->licenceRepo = $container->get('RepositoryServiceManager')
             ->get('Licence');
+        $this->applicationOperatingCentreRepo = $container->get('RepositoryServiceManager')
+            ->get('ApplicationOperatingCentre');
+
         return parent::__invoke($fullContainer, $requestedName, $options);
     }
 }

--- a/module/Api/src/Domain/CommandHandler/Application/ResetApplication.php
+++ b/module/Api/src/Domain/CommandHandler/Application/ResetApplication.php
@@ -111,7 +111,7 @@ final class ResetApplication extends AbstractCommandHandler implements Transacti
             Application::ERROR_REQUIRES_CONFIRMATION
         );
     }
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ResetApplication
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $fullContainer = $container;
 

--- a/module/Api/src/Domain/CommandHandler/Application/ResetApplication.php
+++ b/module/Api/src/Domain/CommandHandler/Application/ResetApplication.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Dvsa\Olcs\Api\Domain\CommandHandler\Application;
 

--- a/module/Api/src/Domain/CommandHandler/Application/ResetApplication.php
+++ b/module/Api/src/Domain/CommandHandler/Application/ResetApplication.php
@@ -75,8 +75,7 @@ final class ResetApplication extends AbstractCommandHandler implements Transacti
         Organisation $organisation,
         mixed $receivedDate = null,
         RefData $appliedVia = null
-    ): Result
-    {
+    ): Result {
         $data = $command->getArrayCopy();
         $data['organisation'] = $organisation->getId();
         $data['appliedVia'] = $appliedVia->getId();

--- a/module/Api/src/Domain/CommandHandler/Application/ResetApplication.php
+++ b/module/Api/src/Domain/CommandHandler/Application/ResetApplication.php
@@ -73,9 +73,10 @@ final class ResetApplication extends AbstractCommandHandler implements Transacti
     private function createNewApplication(
         Cmd $command,
         Organisation $organisation,
-        $receivedDate = null,
+        mixed $receivedDate = null,
         RefData $appliedVia = null
-    ) {
+    ): Result
+    {
         $data = $command->getArrayCopy();
         $data['organisation'] = $organisation->getId();
         $data['appliedVia'] = $appliedVia->getId();

--- a/module/Api/src/Domain/CommandHandler/Traits/ApplicationResetTrait.php
+++ b/module/Api/src/Domain/CommandHandler/Traits/ApplicationResetTrait.php
@@ -1,22 +1,17 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Dvsa\Olcs\Api\Domain\CommandHandler\Traits;
 
 use DateTime;
+use Dvsa\Olcs\Api\Domain\Exception\RuntimeException;
 use Dvsa\Olcs\Api\Entity\Application\Application;
 
-/**
- * Application reset trait
- */
 trait ApplicationResetTrait
 {
     /**
      * Normalise the received date into a format suitable to be passed to the create application/variation command
-     *
-     *
-     * @return string|null
      */
-    private function processReceivedDate(mixed $receivedDate)
+    private function processReceivedDate(mixed $receivedDate): ?string
     {
         if ($receivedDate !== null) {
             if ($receivedDate instanceof DateTime) {
@@ -31,10 +26,7 @@ trait ApplicationResetTrait
 
     /**
      * Close all open tasks relating to the application/variation
-     *
-     * @param Application $application
-     *
-     * return int
+     * @throws RuntimeException
      */
     private function closeTasks(Application $application): int
     {
@@ -47,8 +39,23 @@ trait ApplicationResetTrait
             }
         }
 
-        $this->getRepo()->save($application);
+        $this->applicationRepo->save($application);
 
+        return $count;
+    }
+
+    /**
+     * Deletes the association between the application and its operating centres
+     * @throws RuntimeException
+     */
+    private function removeAssociationOfApplicationAndOperatingCentres(Application $application): int
+    {
+        $count = 0;
+        $applicationOperatingCentres = $application->getOperatingCentres();
+        foreach ($applicationOperatingCentres as $aoc) {
+            $this->applicationOperatingCentreRepo->delete($aoc);
+            $count++;
+        }
         return $count;
     }
 }

--- a/module/Api/src/Domain/CommandHandler/Traits/ApplicationResetTrait.php
+++ b/module/Api/src/Domain/CommandHandler/Traits/ApplicationResetTrait.php
@@ -54,6 +54,11 @@ trait ApplicationResetTrait
     {
         $count = 0;
         $applicationOperatingCentres = $application->getOperatingCentres();
+
+        if (empty($applicationOperatingCentres)) {
+            return $count;
+        }
+
         foreach ($applicationOperatingCentres as $aoc) {
             $this->applicationOperatingCentreRepo->delete($aoc);
             $count++;

--- a/module/Api/src/Domain/CommandHandler/Traits/ApplicationResetTrait.php
+++ b/module/Api/src/Domain/CommandHandler/Traits/ApplicationResetTrait.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Dvsa\Olcs\Api\Domain\CommandHandler\Traits;
 

--- a/module/Api/src/Domain/CommandHandler/Variation/ResetVariation.php
+++ b/module/Api/src/Domain/CommandHandler/Variation/ResetVariation.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Dvsa\Olcs\Api\Domain\CommandHandler\Variation;
 

--- a/module/Api/src/Domain/CommandHandler/Variation/ResetVariation.php
+++ b/module/Api/src/Domain/CommandHandler/Variation/ResetVariation.php
@@ -56,7 +56,7 @@ final class ResetVariation extends AbstractCommandHandler implements Transaction
         return $this->result;
     }
 
-    private function createNewVariation(int $licenceId, ?DateTime $receivedDate, RefData $appliedVia): Result
+    private function createNewVariation(int $licenceId, mixed $receivedDate, RefData $appliedVia): Result
     {
         $data = [
             'id' => $licenceId,

--- a/module/Api/src/Domain/CommandHandler/Variation/ResetVariation.php
+++ b/module/Api/src/Domain/CommandHandler/Variation/ResetVariation.php
@@ -32,7 +32,7 @@ final class ResetVariation extends AbstractCommandHandler implements Transaction
      */
     public function handleCommand(Cmd|CommandInterface $command): Result
     {
-        $application = $this->getRepo()->fetchUsingId($command);
+        $application = $this->applicationRepo->fetchUsingId($command);
 
         $this->validate($command);
 
@@ -46,7 +46,7 @@ final class ResetVariation extends AbstractCommandHandler implements Transaction
         $aocCount = $this->removeAssociationOfApplicationAndOperatingCentres($application);
         $this->result->addMessage($aocCount . ' application operating centres associations removed');
 
-        $this->getRepo()->delete($application);
+        $this->applicationRepo->delete($application);
         $this->result->addMessage('Variation removed');
 
         $this->result->merge(
@@ -76,15 +76,17 @@ final class ResetVariation extends AbstractCommandHandler implements Transaction
      */
     private function validate(Cmd $command): void
     {
-        if ($command->getConfirm() === false) {
-            throw new RequiresConfirmationException(
-                'Updating these elements requires confirmation',
-                Application::ERROR_REQUIRES_CONFIRMATION
-            );
+        if ($command->getConfirm() !== false) {
+            return;
         }
+
+        throw new RequiresConfirmationException(
+            'Updating these elements requires confirmation',
+            Application::ERROR_REQUIRES_CONFIRMATION
+        );
     }
 
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): ResetVariation
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $fullContainer = $container;
 


### PR DESCRIPTION
## Description

Remove association between application and operator on application/variation reset

Related issue: https://dvsa.atlassian.net/browse/VOL-3736

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
