### PR TITLE
fix: Add extra check to CanAccessDocument validator to fix SS bug VOL-5381

### DIFF
--- a/module/Api/src/Domain/Validation/Validators/CanAccessDocument.php
+++ b/module/Api/src/Domain/Validation/Validators/CanAccessDocument.php
@@ -62,7 +62,21 @@ class CanAccessDocument extends AbstractCanAccessEntity
     {
         return $this->checkDocumentWasExternallyUploaded($documentId)
             || $this->checkDocumentInCorrespondence($documentId)
+            || $this->isGVorPSVLicencePrintDocument($documentId)
             || $this->checkIsTxcDocument($documentId);
+    }
+
+    /**
+     * Checks if the cat/sub-cat and description match those expected for a printable licence document linked from SS
+     *
+     * @throws NotFoundException
+     */
+    private function isGVorPSVLicencePrintDocument(string $documentId)
+    {
+        $document = $this->getRepo(Repository\Document::class)->fetchById($documentId);
+        return $document?->getCategory()?->getId() === Entity\System\Category::CATEGORY_LICENSING
+            && $document?->getSubCategory()?->getId() === Entity\System\SubCategory::DOC_SUB_CATEGORY_LICENCING_OTHER_DOCUMENTS
+            && in_array($document?->getDescription(), ['GV Licence', 'PSV Licence']);
     }
 
     private function checkDocumentInCorrespondence(string $documentId): bool

--- a/module/Api/src/Domain/Validation/Validators/CanAccessDocument.php
+++ b/module/Api/src/Domain/Validation/Validators/CanAccessDocument.php
@@ -74,9 +74,19 @@ class CanAccessDocument extends AbstractCanAccessEntity
     private function isGVorPSVLicencePrintDocument(string $documentId)
     {
         $document = $this->getRepo(Repository\Document::class)->fetchById($documentId);
-        return $document?->getCategory()?->getId() === Entity\System\Category::CATEGORY_LICENSING
-            && $document?->getSubCategory()?->getId() === Entity\System\SubCategory::DOC_SUB_CATEGORY_LICENCING_OTHER_DOCUMENTS
-            && in_array($document?->getDescription(), ['GV Licence', 'PSV Licence']);
+
+        if ($document === null) {
+            return false;
+        }
+
+        $category = $document->getCategory();
+        $subCategory = $document->getSubCategory();
+
+        $correctCat = $category !== null && $category->getId() === Entity\System\Category::CATEGORY_LICENSING;
+        $correctSubCat = $subCategory !== null && $subCategory->getId() === Entity\System\SubCategory::DOC_SUB_CATEGORY_LICENCING_OTHER_DOCUMENTS;
+        $correctDescr = in_array($document->getDescription(), ['GV Licence', 'PSV Licence']);
+
+        return $correctCat && $correctSubCat && $correctDescr;
     }
 
     private function checkDocumentInCorrespondence(string $documentId): bool


### PR DESCRIPTION
## Description

Recent tightening of permission in CanAccessDocument validator has prevented the "Print Licence" link on the licence view page. This adds a new check to allow download of matching documents.

Related issue: [VOL-5381](https://dvsa.atlassian.net/browse/VOL-5381)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
