### PR TITLE
feat: downloaded files now use the document description where available

### DIFF
--- a/module/Api/src/Domain/QueryHandler/Document/Download.php
+++ b/module/Api/src/Domain/QueryHandler/Document/Download.php
@@ -30,8 +30,20 @@ class Download extends AbstractDownload
         /* @var \Dvsa\Olcs\Api\Entity\Doc\Document $document */
         $document = $this->getRepo()->fetchById($query->getIdentifier());
 
+        $chosenFileName = null;
+
+        if ($this->isInternalUser()) {
+            $description = $document->getDescription();
+
+            if (!empty($description)) {
+                $chosenFileName = $description;
+            }
+        }
+
         return $this->download(
-            $document->getIdentifier()
+            $document->getIdentifier(),
+            null,
+            $chosenFileName
         );
     }
 }

--- a/module/Api/src/Domain/QueryHandler/Document/DownloadGuide.php
+++ b/module/Api/src/Domain/QueryHandler/Document/DownloadGuide.php
@@ -4,6 +4,7 @@ namespace Dvsa\Olcs\Api\Domain\QueryHandler\Document;
 
 use Dvsa\Olcs\Api\Domain\Exception\NotFoundException;
 use Dvsa\Olcs\Transfer\Query\QueryInterface;
+use Laminas\Http\Response\Stream;
 
 /**
  * Download a guide document, these are located in a "/guides/" directory in the content store
@@ -13,14 +14,11 @@ class DownloadGuide extends AbstractDownload
     protected $extraRepos = ['DocTemplate'];
 
     /**
-     * Handle query
-     *
      * @param \Dvsa\Olcs\Transfer\Query\Document\DownloadGuide $query DTO
      *
-     * @return array
      * @throws NotFoundException
      */
-    public function handleQuery(QueryInterface $query)
+    public function handleQuery(QueryInterface $query): Stream
     {
         $this->setIsInline($query->isInline());
 

--- a/module/DocumentShare/src/Service/DocManClient.php
+++ b/module/DocumentShare/src/Service/DocManClient.php
@@ -111,10 +111,8 @@ class DocManClient implements DocumentStoreInterface
      * Read content from document store
      *
      * @param string $path Path
-     *
-     * @return File|null
      */
-    public function read($path): ?File
+    public function read($path): File | false
     {
         $tmpFileName = tempnam(sys_get_temp_dir(), self::DS_DOWNLOAD_FILE_PREFIX);
 
@@ -132,7 +130,7 @@ class DocManClient implements DocumentStoreInterface
             if (!$response->isSuccess()) {
                 $message = json_encode(["error" => self::ERR_RESP_FAIL, "reason" => $response->getStatusCode(), "path" => $path]);
                 Logger::logResponse($response->getStatusCode(), $message);
-                return null;
+                return false;
             }
 
             $file = new File();
@@ -158,7 +156,7 @@ class DocManClient implements DocumentStoreInterface
             Logger::logResponse(Response::STATUS_CODE_404, $errMssg);
         }
 
-        return null;
+        return false;
     }
 
     /**

--- a/module/DocumentShare/src/Service/WebDavClient.php
+++ b/module/DocumentShare/src/Service/WebDavClient.php
@@ -7,9 +7,6 @@ use League\Flysystem\FileExistsException;
 use League\Flysystem\FileNotFoundException;
 use League\Flysystem\FilesystemInterface;
 
-/**
- * Class Client
- */
 class WebDavClient implements DocumentStoreInterface
 {
     public const DS_DOWNLOAD_FILE_PREFIX = 'ds_dwnld_';
@@ -43,10 +40,8 @@ class WebDavClient implements DocumentStoreInterface
      * Read content from document store
      *
      * @param string $path Path
-     *
-     * @return File|bool
      */
-    public function read($path)
+    public function read($path): File | false
     {
         $tmpFileName = tempnam(sys_get_temp_dir(), self::DS_DOWNLOAD_FILE_PREFIX);
 

--- a/test/module/Api/src/Domain/QueryHandler/Document/AbstractDownloadStub.php
+++ b/test/module/Api/src/Domain/QueryHandler/Document/AbstractDownloadStub.php
@@ -4,15 +4,16 @@ namespace Dvsa\OlcsTest\Api\Domain\QueryHandler\Document;
 
 use Dvsa\Olcs\Api\Domain\QueryHandler\Document\AbstractDownload;
 use Dvsa\Olcs\Transfer\Query\QueryInterface;
+use Laminas\Http\Response\Stream;
 
 /**
  * Stub class of AbstractDownload handler for testing
  */
 class AbstractDownloadStub extends AbstractDownload
 {
-    public function download($identifier, $path = null)
+    public function download(string $identifier, ?string $path = null, ?string $fileName = null): Stream
     {
-        return parent::download($identifier, $path);
+        return parent::download($identifier, $path, $fileName);
     }
 
     public function setIsInline($inline)

--- a/test/module/Api/src/Domain/QueryHandler/Document/AbstractDownloadTest.php
+++ b/test/module/Api/src/Domain/QueryHandler/Document/AbstractDownloadTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Dvsa\OlcsTest\Api\Domain\QueryHandler\Document;
 
 use Dvsa\Olcs\Api\Domain\Exception\NotFoundException;
@@ -46,7 +48,7 @@ class AbstractDownloadTest extends QueryHandlerTestCase
             ->shouldReceive('download')
             ->once()
             ->with($path)
-            ->andReturn(null);
+            ->andReturnFalse();
 
         $this->sut->download($path);
     }
@@ -54,7 +56,7 @@ class AbstractDownloadTest extends QueryHandlerTestCase
     /**
      * @dataProvider dpTestDownload
      */
-    public function testDownload($identifier, $path, $isInline, $expect)
+    public function testDownload($identifier, $path, $isInline, $chosenFileName, $expect)
     {
         $this->sut->setIsInline($isInline);
 
@@ -79,7 +81,7 @@ class AbstractDownloadTest extends QueryHandlerTestCase
             ->andReturn($mockFile);
 
         //  call & check
-        $actual = $this->sut->download($identifier, $path);
+        $actual = $this->sut->download($identifier, $path, $chosenFileName);
 
         static::assertInstanceOf(\Laminas\Http\Response\Stream::class, $actual);
         static::assertEquals($tmpFilePath, $actual->getStreamName());
@@ -101,6 +103,7 @@ class AbstractDownloadTest extends QueryHandlerTestCase
                 'identifier' => 'unit_file.ext',
                 'path' => '/unit_dir/unit_file1.pdf',
                 'isInline' => false,
+                null,
                 'expect' => [
                     'mime' => self::MIME_TYPE,
                     'isDownload' => true,
@@ -112,6 +115,7 @@ class AbstractDownloadTest extends QueryHandlerTestCase
                 'identifier' => 'unit_file.html',
                 'path' => null,
                 'isInline' => false,
+                null,
                 'expect' => [
                     'mime' => self::MIME_TYPE,
                     'isDownload' => false,
@@ -123,6 +127,7 @@ class AbstractDownloadTest extends QueryHandlerTestCase
                 'identifier' => 'dir/dir/unit_file.unit_excl_ext',
                 'path' => null,
                 'isInline' => false,
+                null,
                 'expect' => [
                     'mime' => self::MIME_TYPE_EXCLUDE,
                     'isDownload' => true,
@@ -134,6 +139,7 @@ class AbstractDownloadTest extends QueryHandlerTestCase
                 'identifier' => 'unit_file.ext',
                 'path' => 'unti_path',
                 'isInline' => true,
+                null,
                 'expect' => [
                     'mime' => self::MIME_TYPE,
                     'isDownload' => false,
@@ -145,11 +151,72 @@ class AbstractDownloadTest extends QueryHandlerTestCase
                 'identifier' => '/foo/bar',
                 'path' => null,
                 'isInline' => false,
+                null,
                 'expect' => [
                     'mime' => self::MIME_TYPE,
                     'isDownload' => true,
                     'path' => '/foo/bar',
                     'filename' => 'bar.txt',
+                ],
+            ],
+            [
+                'identifier' => 'unit_file.ext',
+                'path' => '/unit_dir/unit_file1.pdf',
+                'isInline' => false,
+                'chosen_filename',
+                'expect' => [
+                    'mime' => self::MIME_TYPE,
+                    'isDownload' => true,
+                    'path' => '/unit_dir/unit_file1.pdf',
+                    'filename' => 'chosen_filename.ext',
+                ],
+            ],
+            [
+                'identifier' => 'unit_file.html',
+                'path' => null,
+                'isInline' => false,
+                'chosen_filename',
+                'expect' => [
+                    'mime' => self::MIME_TYPE,
+                    'isDownload' => false,
+                    'path' => 'unit_file.html',
+                    'filename' => 'chosen_filename.html',
+                ],
+            ],
+            [
+                'identifier' => 'dir/dir/unit_file.unit_excl_ext',
+                'path' => null,
+                'isInline' => false,
+                'chosen_filename',
+                'expect' => [
+                    'mime' => self::MIME_TYPE_EXCLUDE,
+                    'isDownload' => true,
+                    'path' => 'dir/dir/unit_file.unit_excl_ext',
+                    'filename' => 'chosen_filename.unit_excl_ext',
+                ],
+            ],
+            [
+                'identifier' => 'unit_file.ext',
+                'path' => 'unti_path',
+                'isInline' => true,
+                'chosen_filename.txt',
+                'expect' => [
+                    'mime' => self::MIME_TYPE,
+                    'isDownload' => false,
+                    'path' => 'unti_path',
+                    'filename' => 'chosen_filename.txt.ext',
+                ],
+            ],
+            [
+                'identifier' => '/foo/bar',
+                'path' => null,
+                'isInline' => false,
+                'chosen_filename',
+                'expect' => [
+                    'mime' => self::MIME_TYPE,
+                    'isDownload' => true,
+                    'path' => '/foo/bar',
+                    'filename' => 'chosen_filename.txt',
                 ],
             ],
         ];

--- a/test/module/Api/src/Domain/QueryHandler/Document/DownloadGuideTest.php
+++ b/test/module/Api/src/Domain/QueryHandler/Document/DownloadGuideTest.php
@@ -9,6 +9,7 @@ use Dvsa\Olcs\Transfer\Query as TransferQry;
 use Dvsa\Olcs\Api\Service\File\ContentStoreFileUploader;
 use Dvsa\OlcsTest\Api\Domain\QueryHandler\QueryHandlerTestCase;
 use Dvsa\Olcs\Api\Domain\Repository\DocTemplate as DocTemplateRepo;
+use Laminas\Http\Response\Stream;
 use Mockery as m;
 
 /**
@@ -49,13 +50,14 @@ class DownloadGuideTest extends QueryHandlerTestCase
     public function testHandleQuery()
     {
         $fileName = 'unit_file1.pdf';
+        $file = m::mock(Stream::class);
 
         $this->sut
             ->shouldReceive('setIsInline')->once()->with(false)
             ->shouldReceive('download')
             ->once()
             ->with($fileName, '/guides/' . $fileName)
-            ->andReturn('EXPECTED');
+            ->andReturn($file);
 
         $query = TransferQry\Document\DownloadGuide::create(
             [
@@ -65,13 +67,14 @@ class DownloadGuideTest extends QueryHandlerTestCase
         );
         $actual = $this->sut->handleQuery($query);
 
-        static::assertEquals('EXPECTED', $actual);
+        static::assertEquals($file, $actual);
     }
 
     public function testHandleQueryIsSlug()
     {
         $templateSlug = 'some-template-slug';
         $fileName = 'someFile.txt';
+        $file = m::mock(Stream::class);
 
         $docTemplate = m::mock(DocTemplate::class);
 
@@ -88,7 +91,7 @@ class DownloadGuideTest extends QueryHandlerTestCase
             ->shouldReceive('download')
             ->once()
             ->with($fileName, '/guides/' . $fileName)
-            ->andReturn('EXPECTED');
+            ->andReturn($file);
 
         $query = TransferQry\Document\DownloadGuide::create(
             [
@@ -99,6 +102,6 @@ class DownloadGuideTest extends QueryHandlerTestCase
         );
         $actual = $this->sut->handleQuery($query);
 
-        static::assertEquals('EXPECTED', $actual);
+        static::assertEquals($file, $actual);
     }
 }

--- a/test/module/Api/src/Domain/QueryHandler/Document/DownloadTest.php
+++ b/test/module/Api/src/Domain/QueryHandler/Document/DownloadTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Dvsa\OlcsTest\Api\Domain\QueryHandler\Document;
 
 use Dvsa\Olcs\Api\Domain\QueryHandler\Document\Download;
@@ -7,6 +9,8 @@ use Dvsa\Olcs\Api\Entity\Doc\Document;
 use Dvsa\Olcs\Api\Service\File\ContentStoreFileUploader;
 use Dvsa\Olcs\Transfer\Query as TransferQry;
 use Dvsa\OlcsTest\Api\Domain\QueryHandler\QueryHandlerTestCase;
+use Laminas\Http\Response\Stream;
+use LmcRbacMvc\Service\AuthorizationService;
 use Mockery as m;
 
 /**
@@ -22,6 +26,10 @@ class DownloadTest extends QueryHandlerTestCase
         $this->sut = m::mock(Download::class . '[download, setIsInline]')
             ->shouldAllowMockingProtectedMethods();
 
+        $this->mockedSmServices = [
+            AuthorizationService::class => m::mock(AuthorizationService::class),
+        ];
+
         $this->mockRepo('Document', \Dvsa\Olcs\Api\Domain\Repository\Document::class);
 
         $this->mockedSmServices['config'] = [];
@@ -30,8 +38,12 @@ class DownloadTest extends QueryHandlerTestCase
         parent::setUp();
     }
 
-    public function testHandleQuery()
+    /**
+     * @dataProvider dpTestHandleQuery
+     */
+    public function testHandleQuery(bool $isInternalUser, string $documentDescription, ?string $chosenFilename): void
     {
+        $this->setupIsInternalUser($isInternalUser);
         $identifier = 20062016;
 
         $query = TransferQry\Document\Download::create(
@@ -43,18 +55,32 @@ class DownloadTest extends QueryHandlerTestCase
 
         $fileName = 'foo/bar/12345.pdf';
 
+        $document = m::mock(Document::class);
+        $document->expects('getIdentifier')->withNoArgs()->andReturn($fileName);
+        $document->expects('getDescription')->withNoArgs()->times($isInternalUser ? 1 : 0)->andReturn($documentDescription);
+
         $this->repoMap['Document']
-            ->shouldReceive('fetchById')
+            ->expects('fetchById')
             ->with($identifier)
-            ->once()
-            ->andReturn(new Document($fileName));
+            ->andReturn($document);
+
+        $download = m::mock(Stream::class);
 
         $this->sut
             ->shouldReceive('setIsInline')->once()->with(true)
-            ->shouldReceive('download')->once()->with($fileName)->andReturn('EXPECTED');
+            ->shouldReceive('download')->once()->with($fileName, null, $chosenFilename)->andReturn($download);
 
         $actual = $this->sut->handleQuery($query);
 
-        static::assertEquals('EXPECTED', $actual);
+        static::assertEquals($download, $actual);
+    }
+
+    public function dpTestHandleQuery(): array
+    {
+        return [
+            [false, 'description', null],
+            [true, 'description', 'description'],
+            [true, '', null],
+        ];
     }
 }

--- a/test/module/Api/src/Domain/QueryHandler/QueryHandlerTestCase.php
+++ b/test/module/Api/src/Domain/QueryHandler/QueryHandlerTestCase.php
@@ -8,6 +8,7 @@ use Dvsa\Olcs\Api\Domain\QueryHandler\AbstractQueryHandler;
 use Dvsa\Olcs\Api\Domain\QueryHandler\Result;
 use Dvsa\Olcs\Api\Domain\QueryHandlerManager;
 use Dvsa\Olcs\Api\Domain\RepositoryServiceManager;
+use Dvsa\Olcs\Api\Entity\User\Permission;
 use Dvsa\Olcs\Transfer\Query\Cache\ById as CacheByIdQry;
 use Dvsa\Olcs\Transfer\Query\MyAccount\MyAccount;
 use Dvsa\Olcs\Transfer\Query\QueryInterface;
@@ -309,12 +310,12 @@ class QueryHandlerTestCase extends MockeryTestCase
         $this->expectedQuery(MyAccount::class, [], $result, $times);
     }
 
-    public function expectedTrafficAreaRbacOverride()
+    protected function setupIsInternalUser($isInternalUser = true)
     {
-        $userData = [
-            'dataAccess' => [
-                'trafficAreas' => ["A", "B"],
-            ],
-        ];
+        $this->mockedSmServices[AuthorizationService::class]
+            ->shouldReceive('isGranted')
+            ->with(Permission::INTERNAL_USER, null)
+            ->atLeast()->once()
+            ->andReturn($isInternalUser);
     }
 }

--- a/test/module/Api/src/Service/File/ContentStoreFileUploaderTest.php
+++ b/test/module/Api/src/Service/File/ContentStoreFileUploaderTest.php
@@ -49,12 +49,13 @@ class ContentStoreFileUploaderTest extends MockeryTestCase
 
     public function testDownload()
     {
+        $returnedFile = m::mock(DsFile::class);
         $this->mockContentStoreCli->shouldReceive('read')
             ->once()
             ->with(self::IDENTIFIER)
-            ->andReturn('EXPECT');
+            ->andReturn($returnedFile);
 
-        static::assertEquals('EXPECT', $this->sut->download(self::IDENTIFIER));
+        static::assertEquals($returnedFile, $this->sut->download(self::IDENTIFIER));
     }
 
     public function testRemove()


### PR DESCRIPTION
## Description

Downloaded files now use the document description as the filename

Behaviour is changed for internal users only.

Also fixed inconsistency between how webdav and docman clients return when a file doesn't exist.

Related issue: [VOL-5276](https://dvsa.atlassian.net/browse/VOL-5276)
