### PR TITLE
fix: refactor to use correct `AbstractIndex` contract

### DIFF
--- a/module/Olcs/Db/src/Service/Search/QueryTemplate.php
+++ b/module/Olcs/Db/src/Service/Search/QueryTemplate.php
@@ -5,6 +5,7 @@ namespace Olcs\Db\Service\Search;
 use DomainException;
 use Elastica\Query;
 use InvalidArgumentException;
+use Olcs\Db\Service\Search\Indices\AbstractIndex;
 use Olcs\Db\Service\Search\Indices\Terms\ComplexTermInterface;
 use RuntimeException;
 
@@ -20,6 +21,9 @@ class QueryTemplate extends Query
     public const FILTER_TYPE_COMPLEX = 'COMPLEX';
     public const FILTER_TYPE_BOOLEAN = 'BOOLEAN';
 
+    /**
+     * @param AbstractIndex[] $searchTypes
+     */
     public function __construct(
         string $filename,
         string $searchTerm,
@@ -75,19 +79,12 @@ class QueryTemplate extends Query
 
             switch ($filterTypes[$field]) {
                 case self::FILTER_TYPE_COMPLEX:
-                    $filter = null;
                     foreach ($this->searchTypes as $searchType) {
-                        try {
-                            $filter = $searchType->getFilter($field);
-                        } catch (InvalidArgumentException) {
-                            continue;
-                        }
+                        $filters = $searchType->getFilters();
 
-                        if (!($filter instanceof ComplexTermInterface)) {
-                            continue;
+                        foreach ($filters as $filter) {
+                            $filter->applySearch($this->_params['query']['bool']);
                         }
-
-                        $filter->applySearch($this->_params['query']['bool']);
                     }
                     break;
 

--- a/test/module/Olcs/Db/src/Service/Search/QueryTemplateTest.php
+++ b/test/module/Olcs/Db/src/Service/Search/QueryTemplateTest.php
@@ -31,15 +31,15 @@ class QueryTemplateTest extends m\Adapter\Phpunit\MockeryTestCase
 
     public function queryTemplateDataProvider()
     {
-        $tmls = m::mock(TransportManagerLicenceStatus::class);
-        $tmls->shouldReceive('applySearch')
-             ->andReturnUsing(function (&$params) {
-                 $params['apple'] = 'banana';
-             });
-        $searchType = m::mock(Person::class);
-        $searchType->shouldReceive('getFilter')
-                   ->with('field_6')
-                   ->andReturn($tmls);
+        $transportManagerLicenceStatus = $this->createMock(TransportManagerLicenceStatus::class);
+        $transportManagerLicenceStatus->expects($this->once())->method('applySearch')->willReturnCallback(
+            function (&$params) {
+                $params['apple'] = 'banana';
+            }
+        );
+
+        $personSearchType = $this->createMock(Person::class);
+        $personSearchType->method('getFilters')->willReturn([$transportManagerLicenceStatus]);
 
         return [
             // simple query
@@ -255,7 +255,7 @@ class QueryTemplateTest extends m\Adapter\Phpunit\MockeryTestCase
                     'field_6' => 'COMPLEX',
                 ],
                 [],
-                [$searchType],
+                [$personSearchType],
                 [
                     'bool' => [
                         'must' => [


### PR DESCRIPTION
## Description

The `AbstractIndex->getFilter` isn't a method. This interface did have `getFilters` though. This returned an array of filters. This PR refactors the code to use the correct methods and handle the return types properly.

Related issue: https://dvsa.atlassian.net/browse/VOL-5446

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
