### PR TITLE
fix: fix application open cases method

### DIFF
--- a/module/Api/src/Domain/QueryHandler/Application/Summary.php
+++ b/module/Api/src/Domain/QueryHandler/Application/Summary.php
@@ -225,15 +225,16 @@ class Summary extends AbstractQueryHandler
         $underConsideration = $this->getRepo()->getRefdataReference($application::APPLICATION_STATUS_UNDER_CONSIDERATION)->getId();
         $isUnderConsideration = ($status === $underConsideration);
 
-        try {
-            $openCases = $this->getRepo('Cases')->fetchOpenCasesForApplication($application->getId());
+        /**
+         * @var Repository\Cases $caseRepository
+         */
+        $caseRepository = $this->getRepo('Cases');
 
-            if (count($openCases) > 0) {
-                return false;
-            }
-            return $isUnderConsideration;
-        } catch (\Exception) {
-            return $isUnderConsideration;
+        $openCases = $caseRepository->fetchOpenCasesForApplication($application->getId());
+
+        if (count($openCases) > 0) {
+            return false;
         }
+        return $isUnderConsideration;
     }
 }

--- a/module/Api/src/Domain/Repository/Cases.php
+++ b/module/Api/src/Domain/Repository/Cases.php
@@ -219,11 +219,11 @@ class Cases extends AbstractRepository
     }
 
     /**
+     * @return Entity\Cases\Cases[]
      *
-     * @return mixed
      * @throws Exception\NotFoundException
      */
-    public function fetchOpenCasesForApplication(int $id)
+    public function fetchOpenCasesForApplication(int $id): array
     {
         $qb = $this->createQueryBuilder();
 
@@ -237,10 +237,6 @@ class Cases extends AbstractRepository
             $expr->isNull($this->alias . '.closedDate')
         );
 
-        $result = $qb->getQuery()->getResult();
-        if (!$result) {
-            throw new Exception\NotFoundException('Resource not found');
-        }
-        return $result[0];
+        return $qb->getQuery()->getResult();
     }
 }

--- a/test/module/Api/src/Domain/QueryHandler/Application/SummaryTest.php
+++ b/test/module/Api/src/Domain/QueryHandler/Application/SummaryTest.php
@@ -91,6 +91,7 @@ class SummaryTest extends QueryHandlerTestCase
 
         $mockFee = m::mock()->shouldReceive('getLatestPaymentRef')->andReturn('ref')->once()->getMock();
         $this->mockFeeRepo->shouldReceive('fetchLatestPaidFeeByApplicationId')->with(111)->andReturn($mockFee)->once();
+        $this->mockCaseRepo->shouldReceive('fetchOpenCasesForApplication')->with(111)->andReturn([]);
 
         $result = $this->sut->handleQuery($query);
 
@@ -160,6 +161,7 @@ class SummaryTest extends QueryHandlerTestCase
             ->andReturn('apsts_consideration');
         $mockFee = m::mock()->shouldReceive('getLatestPaymentRef')->andReturn('ref')->once()->getMock();
         $this->mockFeeRepo->shouldReceive('fetchLatestPaidFeeByApplicationId')->with(111)->andReturn($mockFee)->once();
+        $this->mockCaseRepo->shouldReceive('fetchOpenCasesForApplication')->with(111)->andReturn([]);
 
         $result = $this->sut->handleQuery($query);
 
@@ -234,6 +236,7 @@ class SummaryTest extends QueryHandlerTestCase
             ->once()
             ->andReturn('apsts_consideration');
         $this->mockFeeRepo->shouldReceive('fetchLatestPaidFeeByApplicationId')->with(111)->andReturn([])->once();
+        $this->mockCaseRepo->shouldReceive('fetchOpenCasesForApplication')->with(111)->andReturn([]);
 
         $result = $this->sut->handleQuery($query);
 
@@ -305,6 +308,7 @@ class SummaryTest extends QueryHandlerTestCase
             ->andReturn('apsts_consideration');
 
         $this->mockFeeRepo->shouldReceive('fetchLatestPaidFeeByApplicationId')->with(111)->andReturn([])->once();
+        $this->mockCaseRepo->shouldReceive('fetchOpenCasesForApplication')->with(111)->andReturn([]);
 
         $result = $this->sut->handleQuery($query);
 
@@ -368,6 +372,7 @@ class SummaryTest extends QueryHandlerTestCase
 
         $mockFee = m::mock()->shouldReceive('getLatestPaymentRef')->andReturn('ref')->once()->getMock();
         $this->mockFeeRepo->shouldReceive('fetchLatestPaidFeeByApplicationId')->with(111)->andReturn($mockFee)->once();
+        $this->mockCaseRepo->shouldReceive('fetchOpenCasesForApplication')->with(111)->andReturn([]);
 
         $result = $this->sut->handleQuery($query);
 
@@ -435,6 +440,7 @@ class SummaryTest extends QueryHandlerTestCase
 
         $mockFee = m::mock()->shouldReceive('getLatestPaymentRef')->andReturn('ref')->once()->getMock();
         $this->mockFeeRepo->shouldReceive('fetchLatestPaidFeeByApplicationId')->with(111)->andReturn($mockFee)->once();
+        $this->mockCaseRepo->shouldReceive('fetchOpenCasesForApplication')->with(111)->andReturn([]);
 
         $result = $this->sut->handleQuery($query);
 
@@ -504,6 +510,7 @@ class SummaryTest extends QueryHandlerTestCase
             ->andReturn('apsts_consideration');
         $mockFee = m::mock()->shouldReceive('getLatestPaymentRef')->andReturn('ref')->once()->getMock();
         $this->mockFeeRepo->shouldReceive('fetchLatestPaidFeeByApplicationId')->with(111)->andReturn($mockFee)->once();
+        $this->mockCaseRepo->shouldReceive('fetchOpenCasesForApplication')->with(111)->andReturn([]);
 
         $result = $this->sut->handleQuery($query);
 
@@ -565,6 +572,7 @@ class SummaryTest extends QueryHandlerTestCase
 
         $mockFee = m::mock()->shouldReceive('getLatestPaymentRef')->andReturn('ref')->once()->getMock();
         $this->mockFeeRepo->shouldReceive('fetchLatestPaidFeeByApplicationId')->with(111)->andReturn($mockFee)->once();
+        $this->mockCaseRepo->shouldReceive('fetchOpenCasesForApplication')->with(111)->andReturn([$this->createMock(Entity\Cases\Cases::class), $this->createMock(Entity\Cases\Cases::class)]);
 
         $this->mockAppRepo->shouldReceive('fetchUsingId')
             ->once()
@@ -645,6 +653,7 @@ class SummaryTest extends QueryHandlerTestCase
             ->andReturn('apsts_consideration');
         $mockFee = m::mock()->shouldReceive('getLatestPaymentRef')->andReturn('ref')->once()->getMock();
         $this->mockFeeRepo->shouldReceive('fetchLatestPaidFeeByApplicationId')->with(111)->andReturn($mockFee)->once();
+        $this->mockCaseRepo->shouldReceive('fetchOpenCasesForApplication')->with(111)->andReturn([]);
 
         $result = $this->sut->handleQuery($query);
 
@@ -719,6 +728,7 @@ class SummaryTest extends QueryHandlerTestCase
             ->andReturn('apsts_consideration');
         $mockFee = m::mock()->shouldReceive('getLatestPaymentRef')->andReturn('ref')->once()->getMock();
         $this->mockFeeRepo->shouldReceive('fetchLatestPaidFeeByApplicationId')->with(111)->andReturn($mockFee)->once();
+        $this->mockCaseRepo->shouldReceive('fetchOpenCasesForApplication')->with(111)->andReturn([]);
 
         $result = $this->sut->handleQuery($query);
 
@@ -775,6 +785,7 @@ class SummaryTest extends QueryHandlerTestCase
 
         $mockFee = m::mock()->shouldReceive('getLatestPaymentRef')->andReturn('ref')->once()->getMock();
         $this->mockFeeRepo->shouldReceive('fetchLatestPaidFeeByApplicationId')->with(111)->andReturn($mockFee)->once();
+        $this->mockCaseRepo->shouldReceive('fetchOpenCasesForApplication')->with(111)->andReturn([]);
 
         $result = $this->sut->handleQuery($query);
 
@@ -832,6 +843,7 @@ class SummaryTest extends QueryHandlerTestCase
 
         $mockFee = m::mock()->shouldReceive('getLatestPaymentRef')->andReturn('ref')->once()->getMock();
         $this->mockFeeRepo->shouldReceive('fetchLatestPaidFeeByApplicationId')->with(111)->andReturn($mockFee)->once();
+        $this->mockCaseRepo->shouldReceive('fetchOpenCasesForApplication')->with(111)->andReturn([]);
 
         $result = $this->sut->handleQuery($query);
 
@@ -888,7 +900,7 @@ class SummaryTest extends QueryHandlerTestCase
         $this->mockAppRepo->shouldReceive('getRefdataReference->getId')
             ->once()
             ->andReturn('apsts_consideration');
-        $this->mockCaseRepo->shouldReceive('fetchOpenCasesForApplication')->with(111)->andReturn(["case", "case2"]);
+        $this->mockCaseRepo->shouldReceive('fetchOpenCasesForApplication')->with(111)->andReturn([$this->createMock(Entity\Cases\Cases::class), $this->createMock(Entity\Cases\Cases::class)]);
         $mockFee = m::mock()->shouldReceive('getLatestPaymentRef')->andReturn('ref')->once()->getMock();
         $this->mockFeeRepo->shouldReceive('fetchLatestPaidFeeByApplicationId')->with(111)->andReturn($mockFee)->once();
 

--- a/test/module/Api/src/Domain/Repository/CasesTest.php
+++ b/test/module/Api/src/Domain/Repository/CasesTest.php
@@ -340,32 +340,12 @@ class CasesTest extends RepositoryTestCase
         $qb->shouldReceive('getQuery')->andReturn(
             m::mock()->shouldReceive('execute')
                 ->shouldReceive('getResult')
-                ->andReturn(['RESULTS'])
+                ->andReturn([$this->createMock(CasesEntity::class), $this->createMock(CasesEntity::class)])
                 ->getMock()
         );
         $result = $this->sut->fetchOpenCasesForApplication(1);
         $expectedQuery = 'BLAH AND a.id = [[1]] AND m.closedDate IS NULL';
         $this->assertEquals($expectedQuery, $this->query);
-        $this->assertEquals('RESULTS', $result);
-    }
-
-    public function testFetchOpenCasesForApplicationThrowsException(): void
-    {
-        $qb = $this->createMockQb('BLAH');
-
-        $this->mockCreateQueryBuilder($qb);
-
-        $this->queryBuilder
-            ->shouldReceive('modifyQuery')->with($qb)->times(1)->andReturnSelf()
-            ->shouldReceive('with')->with('application', 'a')->andReturnSelf();
-
-        $qb->shouldReceive('getQuery')->andReturn(
-            m::mock()->shouldReceive('execute')
-                ->shouldReceive('getResult')
-                ->andReturn([])
-                ->getMock()
-        );
-        $this->expectException(NotFoundException::class);
-        $this->sut->fetchOpenCasesForApplication(1);
+        $this->assertCount(2, $result);
     }
 }


### PR DESCRIPTION
## Description

The original issue was the `fetchOpenCasesForApplication` returned a Cases Entity object. This isn't countable and throws an error in PHP 8.0+.

Noticed there's quite confusing logic and refactored:
- Strongly typed the `fetchOpenCasesForApplication` to always return an array. 
- Removed the throwing of an exception if there are no open cases, this isn't required and is hiding unit test failures. 
- Updated the unit tests to add more accurate coverage.

Related issue: https://dvsa.atlassian.net/browse/VOL-5469

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
