### PR TITLE
fix: Psalm & Redis IGBinary issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   static-analysis:
-    uses: dvsa/.github/.github/workflows/php-static.yml@main
+    uses: ./.github/workflows/static-analysis.yaml
     with:
       php-version: '8.2'
 

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,0 +1,83 @@
+name: Static analysis
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        required: false
+        type: string
+        default: 'latest'
+      composer-version:
+        required: false
+        type: string
+        default: 'v2'
+
+jobs:
+  phpstan:
+
+    name: PHPStan - ${{ inputs.php-version }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          coverage: none
+          tools: phpstan, composer:${{ inputs.composer-version }}
+
+      - name: Install Composer dependancies
+        run: composer install --no-progress --no-interaction
+
+      - name: Execute PHPStan
+        run: phpstan analyze --no-progress
+
+  php-codesniffer:
+
+    name: PHP-CodeSniffer - ${{ inputs.php-version }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          coverage: none
+          tools: php-cs-fixer, phpcs, composer:${{ inputs.composer-version }}
+
+      - name: Install Composer dependancies
+        run: composer install --no-progress --no-interaction
+
+      - name: Execute PHP CodeSniffer
+        run: phpcs -q
+
+  psalm:
+
+    name: Psalm - ${{ inputs.php-version }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          coverage: none
+          extensions: mbstring, intl, redis-phpredis/phpredis@6.0.2
+          tools: vimeo/psalm, composer:${{ inputs.composer-version }}
+        env:
+          REDIS_CONFIGURE_OPTS: --enable-redis-igbinary
+
+      - name: Install Composer dependancies
+        run: composer install --no-progress --no-interaction
+
+      - name: Execute Psalm
+        run: psalm --no-progress --output-format=github --root=${GITHUB_WORKSPACE}


### PR DESCRIPTION
## Description

This fixes the CI workflow where Psalm now fails because PHP does not have Redis with IGBinary extension enabled (thus constant did not exist).

As a temporary measure, we copy-pasta the Static Analysis workflow from [dvsa/.github/workflows/php-static.yml](https://github.com/dvsa/.github/blob/main/.github/workflows/php-static.yml) and modify Setup PHP to compile Redis from source with support for IGBinary.

Related issue: https://dvsa.atlassian.net/browse/VOL-5559

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
