### PR TITLE
feat: change logging level to `WARN`

### DIFF
--- a/config/autoload/config.global.php
+++ b/config/autoload/config.global.php
@@ -381,7 +381,7 @@ return [
                         'priority' => [
                             'name' => 'priority',
                             'options' => [
-                                'priority' => \Laminas\Log\Logger::DEBUG
+                                'priority' => \Laminas\Log\Logger::WARN
                             ]
                         ],
                     ]

--- a/config/autoload/config.global.php
+++ b/config/autoload/config.global.php
@@ -364,7 +364,7 @@ return [
                         'priority' => [
                             'name' => 'priority',
                             'options' => [
-                                'priority' => \Laminas\Log\Logger::DEBUG
+                                'priority' => \Laminas\Log\Logger::WARN
                             ]
                         ],
                     ]


### PR DESCRIPTION
## Description

As title.

Context is that we're logging a lot of information at the moment and missing vital parts.