### PR TITLE
fix: VOL-3953 prevent bug with queue service from being overwritten

### DIFF
--- a/module/Queue/src/Service/QueueServiceTrait.php
+++ b/module/Queue/src/Service/QueueServiceTrait.php
@@ -26,23 +26,17 @@ trait QueueServiceTrait
      */
     public function setMessageBuilderService(MessageBuilder $messageBuilderService): void
     {
-        if ($this->messageBuilderService === null) {
-            $this->messageBuilderService = $messageBuilderService;
-        }
+        $this->messageBuilderService = $messageBuilderService;
     }
 
     public function setQueueService(Queue $queueService): void
     {
-        if ($this->queueService === null) {
-            $this->queueService = $queueService;
-        }
+        $this->queueService = $queueService;
     }
 
     public function setQueueConfig(array $config): void
     {
-        if ($this->queueConfig === null) {
-            $this->queueConfig = $config;
-        }
+        $this->queueConfig = $config;
     }
 
     protected function getQueueUrlKey($messageType): string

--- a/test/module/Cli/src/Domain/CommandHandler/MessageQueue/Consumer/TransXChange/TransXChangeConsumerTest.php
+++ b/test/module/Cli/src/Domain/CommandHandler/MessageQueue/Consumer/TransXChange/TransXChangeConsumerTest.php
@@ -470,5 +470,6 @@ class TransXChangeConsumerTest extends AbstractCommandHandlerTestCase
         $this->s3Client->shouldReceive('getObject')->andReturn(new \Aws\Result(['Body' => '']));
 
         $this->sut->__invoke($sm, TransXChangeConsumer::class);
+        $this->sut->setQueueService($this->mockedSmServices[Queue::class]);
     }
 }


### PR DESCRIPTION
## Description

Two separate changes were made, to prevent the queue service being overwritten, which cancelled each other out :)

Have reverted one of them, which also handily reverts the code to a previous state and removes risk of the other service using this, companies house, from being impacted.

Related issue: [VOL-3953](https://dvsa.atlassian.net/browse/VOL-3953)
