### PR TITLE
feat: update continuation reminder email template

### DIFF
--- a/module/Email/view/email/en_GB/html/email-inbox-reminder-continuation.phtml
+++ b/module/Email/view/email/en_GB/html/email-inbox-reminder-continuation.phtml
@@ -1,15 +1,6 @@
-<p>Dear operator,</p>
+<?php echo $this->translate('email.inbox-reminder-continuation-html.body'); ?>
 
-<p>We have sent an e-mail to you recently advising that a document relating to your Operator&rsquo;s
- Licence continuation for <?php echo $this->escapeHtml($this->licNo) . ' ' . $this->escapeHtml($this->operatorName); ?>
- has been placed in your Operator Self Service inbox.</p>
-
-<p>We note that this has not yet been read. Please log on to view the correspondence as soon as possible.</p>
-
-<p>Please note that you must print off the continuation document, sign it and return it to the office as
-soon as possible, highlighting any changes to the details on the document.</p>
-
-<p><b>Failure to return the document will result in the termination of your operator licence.</b></p>
+<p>Licence: <?php echo $this->escapeHtml($this->licNo) . ' ' . $this->escapeHtml($this->operatorName); ?></p>
 
 <p>
     <a href="<?php echo $this->escapeHtml($this->url); ?>">Sign in to your account</a>

--- a/module/Email/view/email/en_GB/plain/email-inbox-reminder-continuation.phtml
+++ b/module/Email/view/email/en_GB/plain/email-inbox-reminder-continuation.phtml
@@ -1,11 +1,5 @@
-Dear operator,
+<?php echo $this->translate('email.inbox-reminder-continuation-plain.body'); ?>
 
-We have sent an e-mail to you recently advising that a document relating to your Operator's Licence continuation for <?php echo $this->licNo . ' ' . $this->operatorName; ?> has been placed in your Operator Self Service inbox.
-
-We note that this has not yet been read. Please log on to view the correspondence as soon as possible.
-
-Please note that you must print off the continuation document, sign it and return it to the office as soon as possible, highlighting any changes to the details on the document.
-
-Failure to return the document will result in the termination of your operator licence.
+Licence: <?php echo $this->licNo . ' ' . $this->operatorName; ?>
 
 Sign in to your account at <?php echo $this->url; ?>.


### PR DESCRIPTION
## Description

Update continuation reminder emails to use content from translation keys.

Related issue: [VOL-5695](https://dvsa.atlassian.net/browse/VOL-5695)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
